### PR TITLE
Add layered architecture

### DIFF
--- a/layered/cloud-run/Dockerfile
+++ b/layered/cloud-run/Dockerfile
@@ -1,0 +1,26 @@
+# GCBM Image
+FROM gcr.io/flint-cloud/gcbm:latest
+
+# Allow statements and log messages to immediately appear in the Cloud Run logs
+ENV PYTHONUNBUFFERED True
+
+# Copy application dependency manifests to the container image.
+# Copying this separately prevents re-running pip install on every code change.
+COPY requirements.txt ./
+
+# Install production dependencies.
+RUN python3 -m pip install --upgrade pip && \
+python3 -m pip install --upgrade setuptools && \
+python3 -m pip install -r requirements.txt
+
+# Copy local code to the container image.
+ENV APP_HOME /app
+WORKDIR $APP_HOME
+COPY . ./
+
+# Run the web service on container startup.
+# Use gunicorn webserver with one worker process and 8 threads.
+# For environments with multiple CPU cores, increase the number of workers
+# to be equal to the cores available.
+# Timeout is set to 0 to disable the timeouts of the workers to allow Cloud Run to handle instance scaling.
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app

--- a/layered/cloud-run/main.py
+++ b/layered/cloud-run/main.py
@@ -1,0 +1,206 @@
+import base64
+import logging
+import os
+import json
+import shutil
+import time
+import subprocess
+from datetime import timedelta
+from flask import Flask, request
+from google.cloud import storage, pubsub_v1
+from google.api_core import retry
+from google.api_core.exceptions import AlreadyExists
+
+
+app = Flask(__name__)
+
+os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = 'flint-cloud-81ab3d7821f5.json'
+publisher = pubsub_v1.PublisherClient()
+project = 'flint-cloud'
+
+
+def publish_message(topic, attribs, project='flint-cloud'):
+    """Publish message in given topic"""
+    msg = json.dumps(attribs).encode('utf-8')
+    topic_path = publisher.topic_path(project, topic)
+    return publisher.publish(topic_path, msg)
+
+
+def upload_blob(title, source_file_name):
+    """Uploads a file to the bucket."""
+    # The ID of your GCS bucket
+    bucket_name = "simulation_data_flint-cloud"
+    # The path to your file to upload
+    #source_file_name = "local/path/to/file"
+    # The ID of your GCS object
+    destination_blob_name = "simulations/simulation-"+title+"/"+source_file_name
+
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(destination_blob_name)
+
+    blob.upload_from_filename(source_file_name)
+
+    logging.debug(
+        "File %s uploaded to %s.",
+        source_file_name, destination_blob_name
+    )
+
+
+def download_blob(title, source_blob_name):
+    """Downloads a file from the bucket."""
+    # The ID of your GCS bucket
+    bucket_name = "simulation_data_flint-cloud"
+    # The path to your file to download
+    #source_file_name = "local/path/to/file"
+    # The ID of your GCS object
+    destination_file_name = source_blob_name
+    source_blob_name = "simulations/simulation-"+title+"/"+source_blob_name
+
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(source_blob_name)
+
+    blob.download_to_filename(destination_file_name)
+
+    logging.debug(
+        "File %s downloaded to %s.",
+        source_blob_name, destination_file_name
+    )
+
+
+def generate_download_signed_url_v4(project_dir):
+    """Generates a v4 signed URL for downloading a blob.
+
+    Note that this method requires a service account key file. You can not use
+    this if you are using Application Default Credentials from Google Compute
+    Engine or from the Google Cloud SDK.
+    """
+
+    bucket_name = 'simulation_data_flint-cloud'
+    blob_path = 'simulations/simulation-'+project_dir + '/'
+
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+    blob_input = bucket.blob(blob_path+"input.zip")
+
+    url_input = blob_input.generate_signed_url(
+        version="v4",
+        # This URL is valid for 30 minutes
+        expiration=timedelta(minutes=30),
+        # Allow GET requests using this URL.
+        method="GET",
+    )
+
+    blob_output = bucket.blob(blob_path+"output.zip")
+
+    url_output = blob_output.generate_signed_url(
+        version="v4",
+        # This URL is valid for 30 minutes
+        expiration=timedelta(minutes=30),
+        # Allow GET requests using this URL.
+        method="GET",
+    )
+
+    url = {}
+    url['input'] = url_input
+    url['output'] = url_output
+    url['message'] = 'These links are valid only upto 30 mins. Incase the links expire, you may create a new request.'
+    return url
+
+
+@app.route('/', methods=['POST'])
+def index():
+    envelope = request.get_json()
+    if not envelope:
+        msg = 'no Pub/Sub message received'
+        print(f'error: {msg}')
+        return f'Bad Request: {msg}', 400
+
+    if not isinstance(envelope, dict) or 'message' not in envelope:
+        msg = 'invalid Pub/Sub message format'
+        print(f'error: {msg}')
+        return f'Bad Request: {msg}', 400
+
+    pubsub_message = envelope['message']
+
+    if isinstance(pubsub_message, dict) and 'data' in pubsub_message:
+        msg = base64.b64decode(pubsub_message['data']).decode('utf-8').strip()
+        data = json.loads(msg)
+        topic_name = data['topic']
+        topic_path = publisher.topic_path(project, topic_name)
+        title = data['title']
+        subscription_path = f"{data['subscription']}-internal"
+
+        # Exit if input exists already
+        if os.path.exists(f'/input/{title}'):
+            return '', 204
+
+        subscriber = pubsub_v1.SubscriberClient()
+        with subscriber:
+            try:
+                subscription = subscriber.create_subscription(
+                    request={'name': subscription_path, 'topic': topic_path}
+                )
+            except AlreadyExists:
+                pass
+            response = subscriber.pull(
+                request={'subscription': subscription_path, 'max_messages': 1},
+                retry=retry.Retry(deadline=10),
+            )
+        if len(response.received_messages) > 0:
+            # Simulation already started/finished, ack trigger message and exit
+            return '', 204
+
+        # Publish info message
+        info_msg = {'message': 'Simulation started'}
+        publish_message(topic_name, info_msg)
+
+        # download input from bucket
+        download_blob(title, 'input.zip')
+        if not os.path.exists(f'/input/{title}'):
+            os.makedirs(f'/input/{title}')
+        shutil.unpack_archive('input.zip', f'/input/{title}/')
+        os.remove('input.zip')
+
+        s = time.time()
+        logging.debug('Starting run')
+        with open(f'/input/{title}/gcbm_logs.csv', 'w+') as f:
+            res = subprocess.Popen(['/opt/gcbm/moja.cli', '--config_file', 'gcbm_config.cfg',
+                                    '--config_provider', 'provider_config.json'], stdout=f, cwd=f'/input/{title}')
+        logging.debug('Communicating')
+        (output, err) = res.communicate()
+        logging.debug('Communicated')
+        if not os.path.exists(f'/input/{title}/output'):
+            logging.error(err)
+            publish_message(topic_name, {'error': err})
+            return
+        logging.debug('Output exists')
+        #returncode = final_run(title, gcbm_config_path, provider_config_path, title)
+        shutil.make_archive('output', 'zip', f'/input/{title}/output')
+        shutil.rmtree(f'/input/{title}/output')
+        logging.debug('Made archive')
+        #shutil.make_archive('input', 'zip', f'/input/{title}')
+        shutil.rmtree('/input')
+        upload_blob(title, 'output.zip')
+        logging.debug('Uploaded output')
+        #upload_blob(title, 'input.zip')
+        e = time.time()
+
+        download_url = generate_download_signed_url_v4(title)
+        logging.debug('Generated URL')
+        response = {
+            'exitCode': res.returncode,
+            'execTime': e - s,
+            'response': "Operation executed successfully. Downloadable links for input and output are attached in the response. Alternatively, you may also download this simulation input and output results by making a request at gcbm/download with the title in the body.",
+            'urls': download_url
+        }
+        logging.info(response)
+        publish_message(topic_name, response)
+
+    return '', 204
+
+
+if __name__ == '__main__':
+    PORT = int(os.getenv('PORT')) if os.getenv('PORT') else 8080
+    app.run(host='0.0.0.0', port=PORT)

--- a/layered/cloud-run/requirements.txt
+++ b/layered/cloud-run/requirements.txt
@@ -1,0 +1,4 @@
+Flask==1.1.4
+gunicorn==20.1.0
+google-cloud-storage
+google-cloud-pubsub

--- a/layered/compute-engine/Dockerfile
+++ b/layered/compute-engine/Dockerfile
@@ -1,0 +1,22 @@
+# GCBM Image
+FROM gcr.io/flint-cloud/gcbm:latest
+
+# Allow statements and log messages to immediately appear in the Cloud Run logs
+ENV PYTHONUNBUFFERED True
+
+# Copy application dependency manifests to the container image.
+# Copying this separately prevents re-running pip install on every code change.
+COPY requirements.txt ./
+
+# Install production dependencies.
+RUN python3 -m pip install --upgrade pip && \
+python3 -m pip install --upgrade setuptools && \
+python3 -m pip install -r requirements.txt
+
+# Copy local code to the container image.
+ENV APP_HOME /app
+WORKDIR $APP_HOME
+COPY . ./
+
+# Run startup script
+CMD python3 main.py

--- a/layered/compute-engine/main.py
+++ b/layered/compute-engine/main.py
@@ -1,0 +1,261 @@
+import logging
+import os
+import json
+import shutil
+import time
+import subprocess
+from datetime import timedelta
+from google.cloud import storage, pubsub_v1
+from google.api_core import retry
+from google.api_core.exceptions import AlreadyExists
+from googleapiclient import discovery
+
+
+os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = 'flint-cloud-baec10f8dd27.json'
+publisher = pubsub_v1.PublisherClient()
+project = 'flint-cloud'
+
+
+def create_topic(name, project='flint-cloud'):
+    """Create topic in the given project and subscribe to it. Returns subscription path"""
+    topic_path = publisher.topic_path(project, name)
+    try:
+        topic = publisher.create_topic(request={'name': topic_path})
+    except AlreadyExists:
+        pass
+
+
+def publish_message(topic, attribs, project='flint-cloud'):
+    """Publish message in given topic"""
+    msg = json.dumps(attribs).encode('utf-8')
+    topic_path = publisher.topic_path(project, topic)
+    return publisher.publish(topic_path, msg)
+
+
+def upload_blob(title, source_file_name):
+    """Uploads a file to the bucket."""
+    # The ID of your GCS bucket
+    bucket_name = "simulation_data_flint-cloud"
+    # The path to your file to upload
+    #source_file_name = "local/path/to/file"
+    # The ID of your GCS object
+    destination_blob_name = "simulations/simulation-"+title+"/"+source_file_name
+
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(destination_blob_name)
+
+    blob.upload_from_filename(source_file_name)
+
+    logging.debug(
+        "File %s uploaded to %s.",
+        source_file_name, destination_blob_name
+    )
+
+
+def download_blob(title, source_blob_name):
+    """Downloads a file from the bucket."""
+    # The ID of your GCS bucket
+    bucket_name = "simulation_data_flint-cloud"
+    # The path to your file to download
+    #source_file_name = "local/path/to/file"
+    # The ID of your GCS object
+    destination_file_name = source_blob_name
+    source_blob_name = "simulations/simulation-"+title+"/"+source_blob_name
+
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(source_blob_name)
+
+    blob.download_to_filename(destination_file_name)
+
+    logging.debug(
+        "File %s downloaded to %s.",
+        source_blob_name, destination_file_name
+    )
+
+
+def generate_download_signed_url_v4(project_dir):
+    """Generates a v4 signed URL for downloading a blob.
+
+    Note that this method requires a service account key file. You can not use
+    this if you are using Application Default Credentials from Google Compute
+    Engine or from the Google Cloud SDK.
+    """
+
+    bucket_name = 'simulation_data_flint-cloud'
+    blob_path = 'simulations/simulation-'+project_dir + '/'
+
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+    blob_input = bucket.blob(blob_path+"input.zip")
+
+    url_input = blob_input.generate_signed_url(
+        version="v4",
+        # This URL is valid for 30 minutes
+        expiration=timedelta(minutes=30),
+        # Allow GET requests using this URL.
+        method="GET",
+    )
+
+    blob_output = bucket.blob(blob_path+"output.zip")
+
+    url_output = blob_output.generate_signed_url(
+        version="v4",
+        # This URL is valid for 30 minutes
+        expiration=timedelta(minutes=30),
+        # Allow GET requests using this URL.
+        method="GET",
+    )
+
+    url = {}
+    url['input'] = url_input
+    url['output'] = url_output
+    url['message'] = 'These links are valid only upto 30 mins. Incase the links expire, you may create a new request.'
+    return url
+
+
+def cleanup(subscription_path):
+    subscriber = pubsub_v1.SubscriberClient()
+    with subscriber:
+        response = subscriber.pull(
+            request={'subscription': subscription_path, 'max_messages': 25},
+            retry=retry.Retry(deadline=15),
+        )
+        if len(response.received_messages) > 0:
+            # Simulation already started/finished, exit
+            ack_ids = []
+            for msg in response.received_messages:
+                ack_ids.append(msg.ack_id)
+            subscriber.acknowledge(
+                request={'subscription': subscription_path, 'ack_ids': ack_ids}
+            )
+
+
+def process(data):
+    topic_name = data['topic']
+    topic_path = publisher.topic_path(project, topic_name)
+    title = data['title']
+    subscription_path = f"{data['subscription']}-internal"
+
+    internal_topic_name = f'{topic_name}-internal'
+    internal_topic_path = publisher.topic_path(project, internal_topic_name)
+    create_topic(internal_topic_name)
+
+    # Exit if input exists already
+    if os.path.exists(f'/input/{title}'):
+        return
+
+    subscriber = pubsub_v1.SubscriberClient()
+    with subscriber:
+        try:
+            subscription = subscriber.create_subscription(
+                request={'name': subscription_path,
+                         'topic': internal_topic_path}
+            )
+        except AlreadyExists:
+            pass
+        response = subscriber.pull(
+            request={'subscription': subscription_path, 'max_messages': 1},
+            retry=retry.Retry(deadline=10),
+        )
+        if len(response.received_messages) > 0:
+            # Simulation already started/finished, exit
+            return
+
+    # Publish info message
+    info_msg = {'message': 'Simulation started'}
+    publish_message(topic_name, info_msg)
+    publish_message(internal_topic_name, info_msg)
+
+    # download input from bucket
+    download_blob(title, 'input.zip')
+    if not os.path.exists(f'/input/{title}'):
+        os.makedirs(f'/input/{title}')
+    shutil.unpack_archive('input.zip', f'/input/{title}/')
+    os.remove('input.zip')
+
+    s = time.time()
+    logging.debug('Starting run')
+    with open(f'/input/{title}/gcbm_logs.csv', 'w+') as f:
+        res = subprocess.Popen(['/opt/gcbm/moja.cli', '--config_file', 'gcbm_config.cfg',
+                                '--config_provider', 'provider_config.json'], stdout=f, cwd=f'/input/{title}')
+    logging.debug('Communicating')
+    (output, err) = res.communicate()
+    logging.debug('Communicated')
+    if not os.path.exists(f'/input/{title}/output'):
+        logging.error(err)
+        publish_message(topic_name, {'error': err})
+        return
+    logging.debug('Output exists')
+    #returncode = final_run(title, gcbm_config_path, provider_config_path, title)
+    shutil.make_archive('output', 'zip', f'/input/{title}/output')
+    shutil.rmtree(f'/input/{title}/output')
+    logging.debug('Made archive')
+    #shutil.make_archive('input', 'zip', f'/input/{title}')
+    shutil.rmtree('/input')
+    upload_blob(title, 'output.zip')
+    logging.debug('Uploaded output')
+    #upload_blob(title, 'input.zip')
+    e = time.time()
+
+    download_url = generate_download_signed_url_v4(title)
+    logging.debug('Generated URL')
+    response = {
+        'exitCode': res.returncode,
+        'execTime': e - s,
+        'response': "Operation executed successfully. Downloadable links for input and output are attached in the response. Alternatively, you may also download this simulation input and output results by making a request at gcbm/download with the title in the body.",
+        'urls': download_url
+    }
+    logging.info(response)
+    publish_message(topic_name, response)
+    cleanup(subscription_path)
+
+
+def shutdown():
+    """Stop GCE instance"""
+    service = discovery.build('compute', 'v1')
+
+    project = 'flint-cloud'
+    zone = 'us-central1-a'
+    instance = 'instance-1'
+
+    request = service.instances().stop(project=project, zone=zone, instance=instance)
+    response = request.execute()
+    logging.info(response)
+
+
+if __name__ == '__main__':
+    topic_path = publisher.topic_path(project, 'large-simulations')
+    subscriber = pubsub_v1.SubscriberClient()
+    subscription_path = subscriber.subscription_path(
+        project, 'large-simulations-sub')
+    with subscriber:
+        try:
+            subscription = subscriber.create_subscription(
+                request={'name': subscription_path, 'topic': topic_path}
+            )
+        except AlreadyExists:
+            pass
+        response = subscriber.pull(
+            request={'subscription': subscription_path, 'max_messages': 10},
+            retry=retry.Retry(deadline=10),
+        )
+
+        ack_ids = []
+        for msg in response.received_messages:
+            ack_ids.append(msg.ack_id)
+
+        # Ack all messages
+        if len(ack_ids) > 0:
+            subscriber.acknowledge(
+                request={'subscription': subscription_path, 'ack_ids': ack_ids}
+            )
+
+    for msg in response.received_messages:
+        # Launch run
+        data = json.loads(msg.message.data.decode('utf-8'))
+        logging.debug(data)
+        process(data)
+
+    shutdown()

--- a/layered/compute-engine/requirements.txt
+++ b/layered/compute-engine/requirements.txt
@@ -1,5 +1,3 @@
-Flask==1.1.4
-gunicorn==20.1.0
 google-cloud-storage
 google-cloud-pubsub
 google-api-python-client

--- a/layered/ingress/Dockerfile
+++ b/layered/ingress/Dockerfile
@@ -1,0 +1,24 @@
+# Official Python image
+FROM python:3.9
+
+# Allow statements and log messages to immediately appear in the Cloud Run logs
+ENV PYTHONUNBUFFERED True
+
+# Copy application dependency manifests to the container image.
+# Copying this separately prevents re-running pip install on every code change.
+COPY requirements.txt ./
+
+# Install production dependencies.
+RUN pip install -r requirements.txt
+
+# Copy local code to the container image.
+ENV APP_HOME /app
+WORKDIR $APP_HOME
+COPY . ./
+
+# Run the web service on container startup.
+# Use gunicorn webserver with one worker process and 8 threads.
+# For environments with multiple CPU cores, increase the number of workers
+# to be equal to the cores available.
+# Timeout is set to 0 to disable the timeouts of the workers to allow Cloud Run to handle instance scaling.
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 --timeout 0 main:app

--- a/layered/ingress/Dockerfile
+++ b/layered/ingress/Dockerfile
@@ -4,6 +4,13 @@ FROM python:3.9
 # Allow statements and log messages to immediately appear in the Cloud Run logs
 ENV PYTHONUNBUFFERED True
 
+# Disable interactive prompts
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install packages
+RUN apt-get update -y && \
+apt-get install -y python3-gdal libgdal-dev
+
 # Copy application dependency manifests to the container image.
 # Copying this separately prevents re-running pip install on every code change.
 COPY requirements.txt ./

--- a/layered/ingress/estimate_run_size.py
+++ b/layered/ingress/estimate_run_size.py
@@ -1,0 +1,48 @@
+import os
+from enum import Enum
+from argparse import ArgumentParser
+from glob import glob
+from osgeo import gdal
+from contextlib import contextmanager
+
+
+class SimulationSize(Enum):
+    Small = 1
+    Medium = 2
+    Large = 3
+
+
+@contextmanager
+def open_raster(path):
+    ds = None
+    band = None
+    try:
+        ds = gdal.Open(path)
+        band = ds.GetRasterBand(1)
+        yield band
+    finally:
+        band = None
+        ds = None
+
+
+def estimate_simulation_size(input_data_dir):
+    age_layer_path = glob(os.path.join(input_data_dir, "initial_age*.tiff"))
+    if not age_layer_path:
+        raise RuntimeError(f"Initial age layer not found in {input_data_dir}")
+
+    age_layer_path = age_layer_path[0]
+    with open_raster(age_layer_path) as layer:
+        pixel_count = sum(layer.GetHistogram(approx_ok=0))
+        return SimulationSize.Small if pixel_count < 1e5 \
+            else SimulationSize.Medium if pixel_count < 1e6 \
+            else SimulationSize.Large
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser("Estimate GCBM simulation size.")
+    parser.add_argument(
+        "input_data_dir", help="Path to simulation's tiled layers", type=os.path.abspath)
+    args = parser.parse_args()
+
+    simulation_size = estimate_simulation_size(args.input_data_dir)
+    print(simulation_size)

--- a/layered/ingress/main.py
+++ b/layered/ingress/main.py
@@ -1,0 +1,281 @@
+from flask import Flask, request
+from google.cloud import storage, pubsub_v1
+from google.api_core.exceptions import AlreadyExists
+import json
+import logging
+import os
+import shutil
+
+
+app = Flask(__name__)
+
+os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = 'flint-cloud-81ab3d7821f5.json'
+publisher = pubsub_v1.PublisherClient()
+
+
+def create_topic(name, project='flint-cloud'):
+    """Create topic in the given project and subscribe to it. Returns subscription path"""
+    topic_path = publisher.topic_path(project, name)
+    try:
+        topic = publisher.create_topic(request={'name': topic_path})
+    except AlreadyExists:
+        pass
+
+
+def create_sub(name, project='flint-cloud'):
+    topic_path = publisher.topic_path(project, name)
+    subscriber = pubsub_v1.SubscriberClient()
+    subscription_path = subscriber.subscription_path(project, f'{name}-sub')
+    with subscriber:
+        try:
+            subscription = subscriber.create_subscription(
+                request={'name': subscription_path, 'topic': topic_path}
+            )
+        except AlreadyExists:
+            pass
+    return subscription_path
+
+
+def publish_message(topic, data, project='flint-cloud'):
+    """Publish message in given topic"""
+    create_topic(topic)
+    msg = json.dumps(data).encode('utf-8')
+    topic_path = publisher.topic_path(project, topic)
+    return publisher.publish(topic_path, msg)
+
+
+def upload_blob(title, source_file_name):
+    """Uploads a file to the bucket."""
+    # The ID of your GCS bucket
+    bucket_name = "simulation_data_flint-cloud"
+    # The path to your file to upload
+    #source_file_name = "local/path/to/file"
+    # The ID of your GCS object
+    destination_blob_name = "simulations/simulation-"+title+"/"+source_file_name
+
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(destination_blob_name)
+
+    blob.upload_from_filename(source_file_name)
+
+    logging.debug(
+        "File %s uploaded to %s.",
+        source_file_name, destination_blob_name
+    )
+
+
+def download_blob(title, source_blob_name):
+    """Downloads a file from the bucket."""
+    # The ID of your GCS bucket
+    bucket_name = "simulation_data_flint-cloud"
+    # The path to your file to download
+    #source_file_name = "local/path/to/file"
+    # The ID of your GCS object
+    destination_file_name = source_blob_name
+    source_blob_name = "simulations/simulation-"+title+"/"+source_blob_name
+
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(source_blob_name)
+
+    blob.download_to_filename(destination_file_name)
+
+    logging.debug(
+        "File %s downloaded to %s.",
+        source_blob_name, destination_file_name
+    )
+
+
+@app.route('/gcbm/new', methods=['POST'])
+def gcbm_new():
+    """
+        Upload files for GCBM Dynamic implementation of FLINT
+        ---
+        tags:
+            - gcbm
+        responses:
+            200:
+        parameters:
+                - in: body
+            name: title
+            required: true
+            schema:
+                type: string
+            description: File upload for GCBM Implementation FLINT
+    """
+    # Default title = simulation
+    title = request.form.get('title') or 'simulation'
+    # Sanitize title
+    title = ''.join(c for c in title if c.isalnum())
+    name = 'simulations/simulation-' + title + '/input.zip'
+    storage_client = storage.Client()
+    bucket_name = 'simulation_data_flint-cloud'
+    bucket = storage_client.bucket(bucket_name)
+    stats = storage.Blob(bucket=bucket, name=name).exists(storage_client)
+
+    if not stats:
+        return {'data': "New simulation started. Please move on to the next stage for uploading files at /gcbm/upload."}, 200
+    else:
+        return {'data': "Simulation already exists. Please check the list of simulations present before proceeding with a new simulation at gcbm/list. You may also download the input and output files for this simulation at gcbm/download sending parameter title in the body."}, 400
+
+
+@app.route('/gcbm/upload', methods=['POST'])
+def gcbm_upload():
+    """
+        Upload files for GCBM Dynamic implementation of FLINT
+        ---
+        tags:
+            - gcbm
+        responses:
+            200:
+        parameters:
+                - in: body
+            name: title
+            required: true
+            schema:
+                type: string
+            description: File upload for GCBM Implementation FLINT
+        """
+
+    # Default title = simulation
+    title = request.form.get('title') or 'simulation'
+    # Sanitize title
+    title = ''.join(c for c in title if c.isalnum())
+
+    # Create project directory
+    project_dir = f'{title}'
+    if not os.path.exists(f'/input/{project_dir}'):
+        os.makedirs(f'/input/{project_dir}')
+
+    # Function to flatten paths
+    def fix_path(path):
+        return os.path.basename(path.replace('\\', '/'))
+
+    # Process configuration files
+    if 'config_files' in request.files:
+        for file in request.files.getlist('config_files'):
+            # Fix paths in provider_config
+            if file.filename == 'provider_config.json':
+                provider_config = json.load(file)
+                provider_config['Providers']['SQLite']['path'] = fix_path(
+                    provider_config['Providers']['SQLite']['path'])
+                layers = []
+                for layer in provider_config['Providers']['RasterTiled']['layers']:
+                    layer['layer_path'] = fix_path(layer['layer_path'])
+                    layers.append(layer)
+                provider_config['Providers']['RasterTiled']['layers'] = layers
+                with open(f'/input/{project_dir}/provider_config.json', 'w') as pcf:
+                    json.dump(provider_config, pcf)
+            else:
+                # Save file immediately
+                file.save(f'/input/{project_dir}/{file.filename}')
+    else:
+        return {'error': 'Missing configuration file'}, 400
+
+    # Save input
+    if 'input' in request.files:
+        for file in request.files.getlist('input'):
+            # Save file immediately
+            file.save(f'/input/{project_dir}/{file.filename}')
+    else:
+        return {'error': 'Missing input'}, 400
+
+    # Save db
+    if 'db' in request.files:
+        for file in request.files.getlist('db'):
+            # Save file immediately
+            file.save(f'/input/{project_dir}/{file.filename}')
+    else:
+        return {'error': 'Missing database'}, 400
+
+    # save input in bucket (to maintain state for Cloudrun)
+    shutil.make_archive('input', 'zip', f'/input/{project_dir}')
+    upload_blob(title, 'input.zip')
+
+    return {"data": "All files uploaded sucessfully. Proceed to the next step of the API at gcbm/dynamic."}, 200
+
+
+@app.route('/gcbm/status', methods=['POST'])
+def status():
+    """
+            Get status of a simulation
+            ---
+            tags:
+                    - gcbm
+            responses:
+                    200:
+            parameters:
+                            - in: body
+                    name: title
+                    required: true
+                    schema:
+                            type: string
+                    description: Get status of simulation
+    """
+    # Default title = simulation
+    title = request.form.get('title') or 'simulation'
+    # Sanitize title
+    title = ''.join(c for c in title if c.isalnum())
+
+    # Verify output exists
+    storage_client = storage.Client()
+    bucket_name = 'simulation_data_flint-cloud'
+    bucket = storage_client.bucket(bucket_name)
+    blob_path = f'simulations/simulation-{title}/output.zip'
+    stats = storage.Blob(bucket=bucket, name=blob_path).exists(storage_client)
+    return {'finished': stats}
+
+
+@app.route('/gcbm/dynamic', methods=['POST'])
+def gcbm_dynamic():
+    """
+                Get GCBM Dynamic implementation of FLINT
+                ---
+                tags:
+                        - gcbm
+                responses:
+                        200:
+                parameters:
+                        - in: body
+                        name: title
+                        required: true
+                        schema:
+                                type: string
+                        description: GCBM Implementation FLINT
+                """
+    # Default title = simulation
+    title = request.form.get('title') or 'simulation'
+    # Sanitize title
+    title = ''.join(c for c in title if c.isalnum())
+
+    # Verify simulation exists
+    storage_client = storage.Client()
+    bucket_name = 'simulation_data_flint-cloud'
+    bucket = storage_client.bucket(bucket_name)
+    blob_path = f'simulations/simulation-{title}/input.zip'
+    stats = storage.Blob(bucket=bucket, name=blob_path).exists(storage_client)
+    if not stats:
+        return {'error': 'Simulation not found!'}, 404
+
+    # Create topic and subscriber for simulation
+    topic_name = f'sim-{title}'
+    create_topic(topic_name)
+    subscriber_path = create_sub(topic_name)
+
+    # Submit simulation to Cloud Run/Compute Engine via Pub/Sub
+    # TODO: Determine where to submit the simulation by estimating runtime
+    # TODO: Modify config according to selected environment
+    sim_data = {
+        'topic': topic_name,
+        'title': title,
+        'subscription': subscriber_path 
+    }
+    publish_message('small-simulations', sim_data)
+
+    return {'status': 'Run started', 'subscription': subscriber_path}, 200
+
+
+if __name__ == "__main__":
+    PORT = int(os.getenv("PORT")) if os.getenv("PORT") else 8080
+    app.run(host='0.0.0.0', port=PORT)

--- a/layered/ingress/requirements.txt
+++ b/layered/ingress/requirements.txt
@@ -1,0 +1,4 @@
+Flask==1.1.4
+gunicorn==20.1.0
+google-cloud-storage
+google-cloud-pubsub

--- a/layered/ingress/requirements.txt
+++ b/layered/ingress/requirements.txt
@@ -3,3 +3,4 @@ gunicorn==20.1.0
 google-cloud-storage
 google-cloud-pubsub
 google-api-python-client
+GDAL==2.4.0

--- a/rest_api_gcbm/app.py
+++ b/rest_api_gcbm/app.py
@@ -1,27 +1,26 @@
-from flask import Flask, send_from_directory, request, jsonify, redirect
+from threading import Thread
+from run_distributed import *
+from flask_autoindex import AutoIndex
+from flask_swagger_ui import get_swaggerui_blueprint
+from flask_swagger import swagger
+from datetime import timedelta
+from datetime import datetime
+from google.cloud import storage, pubsub_v1
+from google.api_core.exceptions import AlreadyExists
+import logging
+import shutil
+import json
+import time
+import subprocess
+import os
 import flask.scaffold
 flask.helpers._endpoint_from_view_func = flask.scaffold._endpoint_from_view_func
 from flask_restful import Resource, Api, reqparse
-import os
-import subprocess
-import time
-import json
-import shutil
-import logging
-from google.api_core.exceptions import AlreadyExists
-from google.cloud import storage, pubsub_v1
-from datetime import datetime
-from datetime import timedelta
-from flask_swagger import swagger
-from flask_swagger_ui import get_swaggerui_blueprint
-from flask_autoindex import AutoIndex
-from run_distributed import *
-from threading import Thread
-import logging
+from flask import Flask, send_from_directory, request, jsonify, redirect
 
 app = Flask(__name__)
 # ppath = "/"
-# AutoIndex(app, browse_root=ppath)    
+# AutoIndex(app, browse_root=ppath)
 api = Api(app)
 
 # logger config
@@ -41,503 +40,518 @@ publisher = pubsub_v1.PublisherClient()
 SWAGGER_URL = '/swagger'
 API_URL = '/static/swagger.json'
 SWAGGERUI_BLUEPRINT = get_swaggerui_blueprint(
-	SWAGGER_URL,
-	API_URL,
-	config={
-		'app_name': "FLINT-GCBM REST API"
-	}
+    SWAGGER_URL,
+    API_URL,
+    config={
+        'app_name': "FLINT-GCBM REST API"
+    }
 )
 app.register_blueprint(SWAGGERUI_BLUEPRINT, url_prefix=SWAGGER_URL)
 ### end swagger specific ###
 
 
 def create_topic_and_sub(name, project='flint-cloud'):
-	"""Create topic in the given project and subscribe to it. Returns subscription path"""
-	topic_path = publisher.topic_path(project, name)
-	try:
-		topic = publisher.create_topic(request={'name': topic_path})
-	except AlreadyExists:
-		pass
-	subscriber = pubsub_v1.SubscriberClient()
-	subscription_path = subscriber.subscription_path(project, f'{name}-sub')
-	with subscriber:
-		try:
-			subscription = subscriber.create_subscription(
-				request={'name': subscription_path, 'topic': topic_path}
-			)
-		except AlreadyExists:
-			pass
-	return subscription_path
+    """Create topic in the given project and subscribe to it. Returns subscription path"""
+    topic_path = publisher.topic_path(project, name)
+    try:
+        topic = publisher.create_topic(request={'name': topic_path})
+    except AlreadyExists:
+        pass
+    subscriber = pubsub_v1.SubscriberClient()
+    subscription_path = subscriber.subscription_path(project, f'{name}-sub')
+    with subscriber:
+        try:
+            subscription = subscriber.create_subscription(
+                request={'name': subscription_path, 'topic': topic_path}
+            )
+        except AlreadyExists:
+            pass
+    return subscription_path
 
 
 def publish_message(topic, attribs, project='flint-cloud'):
-	"""Publish message in given topic"""
-	msg = json.dumps(attribs).encode('utf-8')
-	topic_path = publisher.topic_path(project, topic)
-	return publisher.publish(topic_path, msg)
+    """Publish message in given topic"""
+    msg = json.dumps(attribs).encode('utf-8')
+    topic_path = publisher.topic_path(project, topic)
+    return publisher.publish(topic_path, msg)
+
 
 @app.route("/spec")
 def spec():
-	swag = swagger(app)
-	swag['info']['version'] = "1.0"
-	swag['info']['title'] = "FLINT-GCBM Rest Api"
-	f = open("./static/swagger.json", "w+")
-	json.dump(swag,f)
-	return jsonify(swag)
+    swag = swagger(app)
+    swag['info']['version'] = "1.0"
+    swag['info']['title'] = "FLINT-GCBM Rest Api"
+    f = open("./static/swagger.json", "w+")
+    json.dump(swag, f)
+    return jsonify(swag)
+
 
 @app.route('/help/<string:arg>', methods=['GET'])
 def help(arg):
-	"""
-		Get Help Section
-		---
-		tags:
-			- help
-		parameters:
-		- name: arg
-			in: path
-			description: Help info about named section. Pass all to get all info
-			required: true
-			type: string
-		responses:
-			200:
-			description: Help
-		"""
-	s = time.time()
-	if arg=='all':
-		res = subprocess.run(['/opt/gcbm/moja.cli', '--help'], stdout=subprocess.PIPE)
-	else:
-		res = subprocess.run(['/opt/gcbm/moja.cli', '--help-section', arg], stdout=subprocess.PIPE)
-	e = time.time()
-		
-	response = {
-		'exitCode' : res.returncode,
-		'execTime' : e - s,
-		'response' : res.stdout.decode('utf-8')
-	}
-	return {'data': response}, 200
+    """
+            Get Help Section
+            ---
+            tags:
+                    - help
+            parameters:
+            - name: arg
+                    in: path
+                    description: Help info about named section. Pass all to get all info
+                    required: true
+                    type: string
+            responses:
+                    200:
+                    description: Help
+            """
+    s = time.time()
+    if arg == 'all':
+        res = subprocess.run(
+            ['/opt/gcbm/moja.cli', '--help'], stdout=subprocess.PIPE)
+    else:
+        res = subprocess.run(
+            ['/opt/gcbm/moja.cli', '--help-section', arg], stdout=subprocess.PIPE)
+    e = time.time()
+
+    response = {
+        'exitCode': res.returncode,
+        'execTime': e - s,
+        'response': res.stdout.decode('utf-8')
+    }
+    return {'data': response}, 200
 
 
 @app.route('/version', methods=['GET'])
 def version():
-	"""
-		Get Version of FLINT
-		---
-		tags:
-			- version
-		responses:
-			200:
-			description: Version
-		"""
-	s = time.time()
-	res = subprocess.run(['/opt/gcbm/moja.cli', '--version'], stdout=subprocess.PIPE)
-	e = time.time()
-		
-	response = {
-		'exitCode' : res.returncode,
-		'execTime' : e - s,
-		'response' : res.stdout.decode('utf-8')
-	}
-	return {'data': response}, 200
+    """
+            Get Version of FLINT
+            ---
+            tags:
+                    - version
+            responses:
+                    200:
+                    description: Version
+            """
+    s = time.time()
+    res = subprocess.run(
+        ['/opt/gcbm/moja.cli', '--version'], stdout=subprocess.PIPE)
+    e = time.time()
+
+    response = {
+        'exitCode': res.returncode,
+        'execTime': e - s,
+        'response': res.stdout.decode('utf-8')
+    }
+    return {'data': response}, 200
 
 
 @app.route('/gcbm', methods=['POST'])
 def gcbm():
-	"""
-		Get GCBM implementation of FLINT
-		---
-		tags:
-			- gcbm
-		responses:
-			200:
-			description: GCBM Implementation FLINT
-		"""
-	s = time.time()
-	if 'file' in request.files:
-		uploaded_file = request.files['file']
-		if uploaded_file.filename != '':
-			uploaded_file.save(uploaded_file.filename)
-		gcbm_config = uploaded_file.filename
-	else:
-		gcbm_config = 'gcbm_config.cfg'
-		
-	if 'input_db' in request.files:
-		uploaded_file = request.files['input_db']
-		if uploaded_file.filename != '':
-			uploaded_file.save('/gcbm_files/input_database/gcbm_input.db')
-	config_provider = 'provider_config.json'
+    """
+            Get GCBM implementation of FLINT
+            ---
+            tags:
+                    - gcbm
+            responses:
+                    200:
+                    description: GCBM Implementation FLINT
+            """
+    s = time.time()
+    if 'file' in request.files:
+        uploaded_file = request.files['file']
+        if uploaded_file.filename != '':
+            uploaded_file.save(uploaded_file.filename)
+        gcbm_config = uploaded_file.filename
+    else:
+        gcbm_config = 'gcbm_config.cfg'
 
-	dateTimeObj = datetime.now()
-	timestampStr = dateTimeObj.strftime("%H:%M:%S.%f - %b %d %Y")
-	f = open(timestampStr + "point_example.csv", "w+")
-	subprocess.run(["pwd"], cwd="/gcbm_files/config")
-	res = subprocess.Popen(['/opt/gcbm/moja.cli', '--config_file', gcbm_config, '--config_provider', config_provider], stdout=f, cwd='/gcbm_files/config')
-	e = time.time()
-	(output, err) = res.communicate()  
+    if 'input_db' in request.files:
+        uploaded_file = request.files['input_db']
+        if uploaded_file.filename != '':
+            uploaded_file.save('/gcbm_files/input_database/gcbm_input.db')
+    config_provider = 'provider_config.json'
 
-	#This makes the wait possible
-	res_status = res.wait()
-	response = {
-		'exitCode' : res.returncode,
-		'execTime' : e - s,
-		'response' : "Operation executed successfully"
-	}
-	return {'data': response}, 200
-	#return redirect("http://0.0.0.0:8080/gcbm_files/config/..\output", code=302)
-	#UPLOAD_DIRECTORY = "./gcbm_files/config/"	
-	#return send_from_directory(UPLOAD_DIRECTORY,timestampStr + "..\output\gcbm_output.db", as_attachment=True), 200
+    dateTimeObj = datetime.now()
+    timestampStr = dateTimeObj.strftime("%H:%M:%S.%f - %b %d %Y")
+    f = open(timestampStr + "point_example.csv", "w+")
+    subprocess.run(["pwd"], cwd="/gcbm_files/config")
+    res = subprocess.Popen(['/opt/gcbm/moja.cli', '--config_file', gcbm_config,
+                           '--config_provider', config_provider], stdout=f, cwd='/gcbm_files/config')
+    e = time.time()
+    (output, err) = res.communicate()
+
+    # This makes the wait possible
+    res_status = res.wait()
+    response = {
+        'exitCode': res.returncode,
+        'execTime': e - s,
+        'response': "Operation executed successfully"
+    }
+    return {'data': response}, 200
+    # return redirect("http://0.0.0.0:8080/gcbm_files/config/..\output", code=302)
+    #UPLOAD_DIRECTORY = "./gcbm_files/config/"
+    # return send_from_directory(UPLOAD_DIRECTORY,timestampStr + "..\output\gcbm_output.db", as_attachment=True), 200
 
 
 def upload_blob(title, source_file_name):
-	"""Uploads a file to the bucket."""
-	# The ID of your GCS bucket
-	bucket_name = "simulation_data_flint-cloud"
-	# The path to your file to upload
-	#source_file_name = "local/path/to/file"
-	# The ID of your GCS object
-	destination_blob_name = "simulations/simulation-"+title+"/"+source_file_name
+    """Uploads a file to the bucket."""
+    # The ID of your GCS bucket
+    bucket_name = "simulation_data_flint-cloud"
+    # The path to your file to upload
+    #source_file_name = "local/path/to/file"
+    # The ID of your GCS object
+    destination_blob_name = "simulations/simulation-"+title+"/"+source_file_name
 
-	storage_client = storage.Client()
-	bucket = storage_client.bucket(bucket_name)
-	blob = bucket.blob(destination_blob_name)
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(destination_blob_name)
 
-	blob.upload_from_filename(source_file_name)
+    blob.upload_from_filename(source_file_name)
 
-	logger.debug(
-		"File %s uploaded to %s.",
-			source_file_name, destination_blob_name
-	)
+    logger.debug(
+        "File %s uploaded to %s.",
+        source_file_name, destination_blob_name
+    )
 
 
 def download_blob(title, source_blob_name):
-	"""Downloads a file from the bucket."""
-	# The ID of your GCS bucket
-	bucket_name = "simulation_data_flint-cloud"
-	# The path to your file to download
-	#source_file_name = "local/path/to/file"
-	# The ID of your GCS object
-	destination_file_name = source_blob_name
-	source_blob_name = "simulations/simulation-"+title+"/"+source_blob_name
+    """Downloads a file from the bucket."""
+    # The ID of your GCS bucket
+    bucket_name = "simulation_data_flint-cloud"
+    # The path to your file to download
+    #source_file_name = "local/path/to/file"
+    # The ID of your GCS object
+    destination_file_name = source_blob_name
+    source_blob_name = "simulations/simulation-"+title+"/"+source_blob_name
 
-	storage_client = storage.Client()
-	bucket = storage_client.bucket(bucket_name)
-	blob = bucket.blob(source_blob_name)
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(source_blob_name)
 
-	blob.download_to_filename(destination_file_name)
+    blob.download_to_filename(destination_file_name)
 
-	logger.debug(
-		"File %s downloaded to %s.",
-			source_blob_name, destination_file_name
-	)
+    logger.debug(
+        "File %s downloaded to %s.",
+        source_blob_name, destination_file_name
+    )
 
 
 @app.route('/gcbm/new', methods=['POST'])
 def gcbm_new():
-	"""
-		Upload files for GCBM Dynamic implementation of FLINT
-		---
-		tags:
-			- gcbm
-		responses:
-			200:
-		parameters:
-				- in: body
-			name: title
-			required: true
-			schema:
-				type: string
-			description: File upload for GCBM Implementation FLINT
-	"""
-	# Default title = simulation
-	title = request.form.get('title') or 'simulation'
-	# Sanitize title
-	title = ''.join(c for c in title if c.isalnum())
-	name = 'simulations/simulation-'+ title + '/input.zip'   
-	storage_client = storage.Client()
-	bucket_name = 'simulation_data_flint-cloud'
-	bucket = storage_client.bucket(bucket_name)
-	stats = storage.Blob(bucket=bucket, name=name).exists(storage_client)
+    """
+            Upload files for GCBM Dynamic implementation of FLINT
+            ---
+            tags:
+                    - gcbm
+            responses:
+                    200:
+            parameters:
+                            - in: body
+                    name: title
+                    required: true
+                    schema:
+                            type: string
+                    description: File upload for GCBM Implementation FLINT
+    """
+    # Default title = simulation
+    title = request.form.get('title') or 'simulation'
+    # Sanitize title
+    title = ''.join(c for c in title if c.isalnum())
+    name = 'simulations/simulation-' + title + '/input.zip'
+    storage_client = storage.Client()
+    bucket_name = 'simulation_data_flint-cloud'
+    bucket = storage_client.bucket(bucket_name)
+    stats = storage.Blob(bucket=bucket, name=name).exists(storage_client)
 
-	if not stats:
-		return {'data': "New simulation started. Please move on to the next stage for uploading files at /gcbm/upload."}, 200
-	else:
-		return {'data': "Simulation already exists. Please check the list of simulations present before proceeding with a new simulation at gcbm/list. You may also download the input and output files for this simulation at gcbm/download sending parameter title in the body."}, 400
+    if not stats:
+        return {'data': "New simulation started. Please move on to the next stage for uploading files at /gcbm/upload."}, 200
+    else:
+        return {'data': "Simulation already exists. Please check the list of simulations present before proceeding with a new simulation at gcbm/list. You may also download the input and output files for this simulation at gcbm/download sending parameter title in the body."}, 400
 
 
 @app.route('/gcbm/upload', methods=['POST'])
 def gcbm_upload():
-	"""
-		Upload files for GCBM Dynamic implementation of FLINT
-		---
-		tags:
-			- gcbm
-		responses:
-			200:
-		parameters:
-				- in: body
-			name: title
-			required: true
-			schema:
-				type: string
-			description: File upload for GCBM Implementation FLINT
-		"""
+    """
+            Upload files for GCBM Dynamic implementation of FLINT
+            ---
+            tags:
+                    - gcbm
+            responses:
+                    200:
+            parameters:
+                            - in: body
+                    name: title
+                    required: true
+                    schema:
+                            type: string
+                    description: File upload for GCBM Implementation FLINT
+            """
 
-	# Default title = simulation
-	title = request.form.get('title') or 'simulation'
-	# Sanitize title
-	title = ''.join(c for c in title if c.isalnum())
+    # Default title = simulation
+    title = request.form.get('title') or 'simulation'
+    # Sanitize title
+    title = ''.join(c for c in title if c.isalnum())
 
-	# Create project directory
-	project_dir = f'{title}'
-	if not os.path.exists(f'/input/{project_dir}'):
-		os.makedirs(f'/input/{project_dir}')
+    # Create project directory
+    project_dir = f'{title}'
+    if not os.path.exists(f'/input/{project_dir}'):
+        os.makedirs(f'/input/{project_dir}')
 
-	# Function to flatten paths
-	def fix_path(path):
-		return os.path.basename(path.replace('\\', '/'))
+    # Function to flatten paths
+    def fix_path(path):
+        return os.path.basename(path.replace('\\', '/'))
 
-	# Process configuration files
-	if 'config_files' in request.files:
-		for file in request.files.getlist('config_files'):
-			# Fix paths in provider_config
-			if file.filename == 'provider_config.json':
-				provider_config = json.load(file)
-				provider_config['Providers']['SQLite']['path'] = fix_path(provider_config['Providers']['SQLite']['path'])
-				layers = []
-				for layer in provider_config['Providers']['RasterTiled']['layers']:
-					layer['layer_path'] = fix_path(layer['layer_path'])
-					layers.append(layer)
-				provider_config['Providers']['RasterTiled']['layers'] = layers
-				with open(f'/input/{project_dir}/provider_config.json', 'w') as pcf:
-					json.dump(provider_config, pcf)
-			else:
-				# Save file immediately
-				file.save(f'/input/{project_dir}/{file.filename}')
-	else:
-		return {'error': 'Missing configuration file'}, 400
-	
-	# Save input 
-	if 'input' in request.files:
-		for file in request.files.getlist('input'):
-			# Save file immediately
-			file.save(f'/input/{project_dir}/{file.filename}')
-	else:
-		return {'error': 'Missing input'}, 400
+    # Process configuration files
+    if 'config_files' in request.files:
+        for file in request.files.getlist('config_files'):
+            # Fix paths in provider_config
+            if file.filename == 'provider_config.json':
+                provider_config = json.load(file)
+                provider_config['Providers']['SQLite']['path'] = fix_path(
+                    provider_config['Providers']['SQLite']['path'])
+                layers = []
+                for layer in provider_config['Providers']['RasterTiled']['layers']:
+                    layer['layer_path'] = fix_path(layer['layer_path'])
+                    layers.append(layer)
+                provider_config['Providers']['RasterTiled']['layers'] = layers
+                with open(f'/input/{project_dir}/provider_config.json', 'w') as pcf:
+                    json.dump(provider_config, pcf)
+            else:
+                # Save file immediately
+                file.save(f'/input/{project_dir}/{file.filename}')
+    else:
+        return {'error': 'Missing configuration file'}, 400
 
-	# Save db
-	if 'db' in request.files:
-		for file in request.files.getlist('db'):
-			# Save file immediately
-			file.save(f'/input/{project_dir}/{file.filename}')
-	else:
-		return {'error': 'Missing database'}, 400
+    # Save input
+    if 'input' in request.files:
+        for file in request.files.getlist('input'):
+            # Save file immediately
+            file.save(f'/input/{project_dir}/{file.filename}')
+    else:
+        return {'error': 'Missing input'}, 400
 
-	#save input in bucket (to maintain state for Cloudrun)
-	shutil.make_archive('input', 'zip', f'/input/{project_dir}')
-	upload_blob(title, 'input.zip')
+    # Save db
+    if 'db' in request.files:
+        for file in request.files.getlist('db'):
+            # Save file immediately
+            file.save(f'/input/{project_dir}/{file.filename}')
+    else:
+        return {'error': 'Missing database'}, 400
 
-	return {"data": "All files uploaded sucessfully. Proceed to the next step of the API at gcbm/dynamic."}, 200
+    # save input in bucket (to maintain state for Cloudrun)
+    shutil.make_archive('input', 'zip', f'/input/{project_dir}')
+    upload_blob(title, 'input.zip')
+
+    return {"data": "All files uploaded sucessfully. Proceed to the next step of the API at gcbm/dynamic."}, 200
 
 
 @app.route('/gcbm/dynamic', methods=['POST'])
 def gcbm_dynamic():
-	"""
-		Get GCBM Dynamic implementation of FLINT
-		---
-		tags:
-			- gcbm
-		responses:
-			200:
-		parameters:
-				- in: body
-			name: title
-			required: true
-			schema:
-				type: string
-			description: GCBM Implementation FLINT
-		"""
-	# Default title = simulation
-	title = request.form.get('title') or 'simulation'
-	# Sanitize title
-	title = ''.join(c for c in title if c.isalnum())
-	project_dir = f'{title}'
+    """
+                Get GCBM Dynamic implementation of FLINT
+                ---
+                tags:
+                        - gcbm
+                responses:
+                        200:
+                parameters:
+                        - in: body
+                        name: title
+                        required: true
+                        schema:
+                                type: string
+                        description: GCBM Implementation FLINT
+                """
+    # Default title = simulation
+    title = request.form.get('title') or 'simulation'
+    # Sanitize title
+    title = ''.join(c for c in title if c.isalnum())
+    project_dir = f'{title}'
 
-	gcbm_config_path = 'gcbm_config.cfg'
-	provider_config_path = 'provider_config.json'
+    gcbm_config_path = 'gcbm_config.cfg'
+    provider_config_path = 'provider_config.json'
 
-	#download input from bucket
-	download_blob(title, 'input.zip')
-	if not os.path.exists(f'/input/{project_dir}'):
-		os.makedirs(f'/input/{project_dir}')
-	shutil.unpack_archive('input.zip', f'/input/{project_dir}/')
-	os.remove('input.zip')
+    # download input from bucket
+    download_blob(title, 'input.zip')
+    if not os.path.exists(f'/input/{project_dir}'):
+        os.makedirs(f'/input/{project_dir}')
+    shutil.unpack_archive('input.zip', f'/input/{project_dir}/')
+    os.remove('input.zip')
 
-	thread = Thread(target=launch_run, kwargs={'title': title, 'project_dir': project_dir})
-	thread.start()
-	subscriber_path = create_topic_and_sub(title)
-	return {'status': 'Run started', 'subscription': subscriber_path}, 200
+    thread = Thread(target=launch_run, kwargs={
+                    'title': title, 'project_dir': project_dir})
+    thread.start()
+    subscriber_path = create_topic_and_sub(title)
+    return {'status': 'Run started', 'subscription': subscriber_path}, 200
+
 
 def launch_run(title, project_dir):
-		s = time.time()
-		logging.debug('Starting run')
-		with open(f'/input/{project_dir}/gcbm_logs.csv', 'w+') as f:
-			res = subprocess.Popen(['/opt/gcbm/moja.cli', '--config_file' , 'gcbm_config.cfg', '--config_provider', 'provider_config.json'], stdout=f, cwd=f'/input/{project_dir}')
-		logging.debug('Communicating')
-		(output, err) = res.communicate()
-		logging.debug('Communicated')
-		if not os.path.exists(f'/input/{project_dir}/output'):
-			logging.error(err)
-			publish_message(title, {'error': err})
-			return
-		logging.debug('Output exists')
-		#returncode = final_run(title, gcbm_config_path, provider_config_path, project_dir)
-		shutil.make_archive('output', 'zip', f'/input/{project_dir}/output')
-		shutil.rmtree(f'/input/{project_dir}/output')
-		logging.debug('Made archive')
-		#shutil.make_archive('input', 'zip', f'/input/{project_dir}')
-		shutil.rmtree('/input')
-		upload_blob(title, 'output.zip')
-		logging.debug('Uploaded output')
-		#upload_blob(title, 'input.zip')
-		e = time.time()
+    s = time.time()
+    logging.debug('Starting run')
+    with open(f'/input/{project_dir}/gcbm_logs.csv', 'w+') as f:
+        res = subprocess.Popen(['/opt/gcbm/moja.cli', '--config_file', 'gcbm_config.cfg',
+                               '--config_provider', 'provider_config.json'], stdout=f, cwd=f'/input/{project_dir}')
+    logging.debug('Communicating')
+    (output, err) = res.communicate()
+    logging.debug('Communicated')
+    if not os.path.exists(f'/input/{project_dir}/output'):
+        logging.error(err)
+        publish_message(title, {'error': err})
+        return
+    logging.debug('Output exists')
+    #returncode = final_run(title, gcbm_config_path, provider_config_path, project_dir)
+    shutil.make_archive('output', 'zip', f'/input/{project_dir}/output')
+    shutil.rmtree(f'/input/{project_dir}/output')
+    logging.debug('Made archive')
+    #shutil.make_archive('input', 'zip', f'/input/{project_dir}')
+    shutil.rmtree('/input')
+    upload_blob(title, 'output.zip')
+    logging.debug('Uploaded output')
+    #upload_blob(title, 'input.zip')
+    e = time.time()
 
-		download_url = generate_download_signed_url_v4(project_dir)
-		logging.debug('Generated URL')
-		response = {
-			'exitCode' : res.returncode,
-			'execTime' : e - s,
-			'response' : "Operation executed successfully. Downloadable links for input and output are attached in the response. Alternatively, you may also download this simulation input and output results by making a request at gcbm/download with the title in the body.",
-			'urls': download_url
-		}
-		logging.info(response)
-		publish_message(title, response)
+    download_url = generate_download_signed_url_v4(project_dir)
+    logging.debug('Generated URL')
+    response = {
+        'exitCode': res.returncode,
+        'execTime': e - s,
+        'response': "Operation executed successfully. Downloadable links for input and output are attached in the response. Alternatively, you may also download this simulation input and output results by making a request at gcbm/download with the title in the body.",
+        'urls': download_url
+    }
+    logging.info(response)
+    publish_message(title, response)
+
 
 def generate_download_signed_url_v4(project_dir):
-	"""Generates a v4 signed URL for downloading a blob.
+    """Generates a v4 signed URL for downloading a blob.
 
-	Note that this method requires a service account key file. You can not use
-	this if you are using Application Default Credentials from Google Compute
-	Engine or from the Google Cloud SDK.
-	"""
-	
-	bucket_name = 'simulation_data_flint-cloud'
-	blob_path = 'simulations/simulation-'+project_dir + '/' 
+    Note that this method requires a service account key file. You can not use
+    this if you are using Application Default Credentials from Google Compute
+    Engine or from the Google Cloud SDK.
+    """
 
-	storage_client = storage.Client()
-	bucket = storage_client.bucket(bucket_name)
-	blob_input = bucket.blob(blob_path+"input.zip")
+    bucket_name = 'simulation_data_flint-cloud'
+    blob_path = 'simulations/simulation-'+project_dir + '/'
 
-	url_input = blob_input.generate_signed_url(
-		version="v4",
-		# This URL is valid for 30 minutes
-		expiration=timedelta(minutes=30),
-		# Allow GET requests using this URL.
-		method="GET",
-	)
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+    blob_input = bucket.blob(blob_path+"input.zip")
 
-	blob_output = bucket.blob(blob_path+"output.zip")
+    url_input = blob_input.generate_signed_url(
+        version="v4",
+        # This URL is valid for 30 minutes
+        expiration=timedelta(minutes=30),
+        # Allow GET requests using this URL.
+        method="GET",
+    )
 
-	url_output = blob_output.generate_signed_url(
-		version="v4",
-		# This URL is valid for 30 minutes
-		expiration=timedelta(minutes=30),
-		# Allow GET requests using this URL.
-		method="GET",
-	)
+    blob_output = bucket.blob(blob_path+"output.zip")
 
-	url = {}
-	url['input'] = url_input
-	url['output'] = url_output
-	url['message'] = 'These links are valid only upto 30 mins. Incase the links expire, you may create a new request.'
-	return url
+    url_output = blob_output.generate_signed_url(
+        version="v4",
+        # This URL is valid for 30 minutes
+        expiration=timedelta(minutes=30),
+        # Allow GET requests using this URL.
+        method="GET",
+    )
+
+    url = {}
+    url['input'] = url_input
+    url['output'] = url_output
+    url['message'] = 'These links are valid only upto 30 mins. Incase the links expire, you may create a new request.'
+    return url
+
 
 @app.route('/gcbm/download', methods=['POST'])
 def gcbm_download():
-	"""
-		Download GCBM Input and Output
-		---
-		tags:
-			- gcbm
-		responses:
-			200:
-		parameters:
-				- in: body
-			name: title
-			required: true
-			schema:
-				type: string
-			description: GCBM Download FLINT
-		"""
-	# Default title = simulation
-	title = request.form.get('title') or 'simulation'
-	# Sanitize title
-	title = ''.join(c for c in title if c.isalnum())
-	project_dir = f'{title}'
-	url= generate_download_signed_url_v4('simulations/'+project_dir)
+    """
+            Download GCBM Input and Output
+            ---
+            tags:
+                    - gcbm
+            responses:
+                    200:
+            parameters:
+                            - in: body
+                    name: title
+                    required: true
+                    schema:
+                            type: string
+                    description: GCBM Download FLINT
+                """
+    # Default title = simulation
+    title = request.form.get('title') or 'simulation'
+    # Sanitize title
+    title = ''.join(c for c in title if c.isalnum())
+    project_dir = f'{title}'
+    url = generate_download_signed_url_v4('simulations/'+project_dir)
 
-	return url, 200
+    return url, 200
+
 
 @app.route('/gcbm/list', methods=['GET'])
 def gcbm_list_simulations():
-	"""
-		Get GCBM Simulations List
-		---
-		tags:
-			- gcbm
-		responses:
-			200:
-		description: GCBM Simulations List
-		"""
-	storage_client = storage.Client()
-	bucket_name = 'simulation_data_flint-cloud'
-	blobs = storage_client.list_blobs(bucket_name, prefix='simulations/')
-	blob_map = {}
-	blob_list = []
-	for blob in blobs:
-		dir_name = blob.name.split('/')[1]
-		if dir_name not in blob_map:
-			blob_map[dir_name] = 1
-			blob_list.append(dir_name)
+    """
+            Get GCBM Simulations List
+            ---
+            tags:
+                    - gcbm
+            responses:
+                    200:
+            description: GCBM Simulations List
+                """
+    storage_client = storage.Client()
+    bucket_name = 'simulation_data_flint-cloud'
+    blobs = storage_client.list_blobs(bucket_name, prefix='simulations/')
+    blob_map = {}
+    blob_list = []
+    for blob in blobs:
+        dir_name = blob.name.split('/')[1]
+        if dir_name not in blob_map:
+            blob_map[dir_name] = 1
+            blob_list.append(dir_name)
 
-	return {'data':blob_list, 'message': "To create a new simulation, create a request at gcbm/new. To access the results of the existing simulations, create a request at gcbm/download."}, 200		
+    return {'data': blob_list, 'message': "To create a new simulation, create a request at gcbm/new. To access the results of the existing simulations, create a request at gcbm/download."}, 200
 
 
 @app.route('/gcbm/status', methods=['POST'])
 def status():
-	"""
-		Get status of a simulation
-		---
-		tags:
-			- gcbm
-		responses:
-			200:
-		parameters:
-				- in: body
-			name: title
-			required: true
-			schema:
-				type: string
-			description: Get status of simulation
-	"""
-	# Default title = simulation
-	title = request.form.get('title') or 'simulation'
-	# Sanitize title
-	title = ''.join(c for c in title if c.isalnum())
+    """
+            Get status of a simulation
+            ---
+            tags:
+                    - gcbm
+            responses:
+                    200:
+            parameters:
+                            - in: body
+                    name: title
+                    required: true
+                    schema:
+                            type: string
+                    description: Get status of simulation
+    """
+    # Default title = simulation
+    title = request.form.get('title') or 'simulation'
+    # Sanitize title
+    title = ''.join(c for c in title if c.isalnum())
 
-	storage_client = storage.Client()
-	bucket_name = 'simulation_data_flint-cloud'
-	bucket = storage_client.bucket(bucket_name)
-	blob_path = f'simulations/simulation-{title}/output.zip'
-	stats = storage.Blob(bucket=bucket, name=blob_path).exists(storage_client)
-	return {'finished': stats}
+    storage_client = storage.Client()
+    bucket_name = 'simulation_data_flint-cloud'
+    bucket = storage_client.bucket(bucket_name)
+    blob_path = f'simulations/simulation-{title}/output.zip'
+    stats = storage.Blob(bucket=bucket, name=blob_path).exists(storage_client)
+    return {'finished': stats}
 
 
 @app.route('/check', methods=['GET', 'POST'])
 def check():
-	return 'Checks OK', 200
+    return 'Checks OK', 200
+
 
 @app.route('/', methods=['GET'])
 def home():
-	return 'FLINT.Cloud API'
+    return 'FLINT.Cloud API'
+
 
 if __name__ == '__main__':
-	app.run(debug=True, host='0.0.0.0', port=int(os.environ.get('PORT', 8080)))
+    app.run(debug=True, host='0.0.0.0', port=int(os.environ.get('PORT', 8080)))


### PR DESCRIPTION
This pull request switches the API to a two-tiered architecture.
There are two layers: ingress and processing layers.
![archi](https://user-images.githubusercontent.com/34343421/118666444-d22bb780-b810-11eb-96c5-ade584830876.png)

1. The ingress service is a Cloud Run service, running on a bare Python container. It has the same three endpoints as before for creating a new run, uploading files, and starting the simulation. However, now when the user uploads the simulation files, the server runs a heuristic (provided by Max), that estimates the size of the simulation. The medium and small simulations are forwarded via Pub/Sub to another Cloud Run service and the large simulations to a compute engine instance.
2. The small and medium runs are handled by a Cloud Run service (cr-processor) which is tasked exclusively with running the simulations and nothing else. It's a GCBM image with a small flask app on top (to receive Pub/Sub requests). After the simulation is complete, it drops a message on Pub/Sub topic for that simulation and uploads the output.
3. The compute engine instance runs another GCBM image, with a python script to run the simulations. The compute engine instance is kept in the stopped state by default (to save unnecessary charges). When the ingress service receives a request to run a large simulation, it spins up the instance (using gcloud API), which in turn spins up the script. This script checks on Pub/Sub for all pending large runs and sequentially processes them. After it runs out of simulations to process, it returns to the stopped state again (by using gcloud API). The completion of runs is again, communicated via Pub/Sub topic for that simulation.