### PR TITLE
Fix paths in modules_output.json

### DIFF
--- a/layered/ingress/main.py
+++ b/layered/ingress/main.py
@@ -179,6 +179,13 @@ def gcbm_upload():
                 provider_config['Providers']['RasterTiled']['layers'] = layers
                 with open(f'/input/{project_dir}/provider_config.json', 'w') as pcf:
                     json.dump(provider_config, pcf)
+            # Fix paths in modules_output
+            elif file.filename == 'modules_output.json':
+                modules_output = json.load(file)
+                modules_output['Modules']['CBMAggregatorSQLiteWriter']['settings']['databasename'] = 'output/gcbm_output.db'
+                modules_output['Modules']['WriteVariableGeotiff']['settings']['output_path'] = 'output'
+                with open(f'/input/{project_dir}/modules_output.json', 'w') as mof:
+                    json.dump(modules_output, mof)
             else:
                 # Save file immediately
                 file.save(f'/input/{project_dir}/{file.filename}')

--- a/rest_api_gcbm/app.py
+++ b/rest_api_gcbm/app.py
@@ -315,6 +315,13 @@ def gcbm_upload():
                 provider_config['Providers']['RasterTiled']['layers'] = layers
                 with open(f'/input/{project_dir}/provider_config.json', 'w') as pcf:
                     json.dump(provider_config, pcf)
+            # Fix paths in modules_output
+            elif file.filename == 'modules_output.json':
+                modules_output = json.load(file)
+                modules_output['Modules']['CBMAggregatorSQLiteWriter']['settings']['databasename'] = 'output/gcbm_output.db'
+                modules_output['Modules']['WriteVariableGeotiff']['settings']['output_path'] = 'output'
+                with open(f'/input/{project_dir}/modules_output.json', 'w') as mof:
+                    json.dump(modules_output, mof)
             else:
                 # Save file immediately
                 file.save(f'/input/{project_dir}/{file.filename}')


### PR DESCRIPTION
This PR fixes the missing `gcbm_output.db` file in the output. This problem arises due to the database output path set to an incorrect location in the config.
Now, the API will fix the paths in the input before storing them.

- Changes the paths in modules_output.json
  - Change `modules_output.Modules.CBMAggregatorSQLiteWriter.settings.databasename` to `output/gcbm_output.db`
  - Change `modules_output.Modules.WriteVariableGeotiff.settings.output_path` to `output`