### PR TITLE
Terraform script to provision cloud infrastructure

### DIFF
--- a/layered/cloud-run/main.py
+++ b/layered/cloud-run/main.py
@@ -15,7 +15,9 @@ from google.api_core.exceptions import AlreadyExists
 app = Flask(__name__)
 
 project = os.environ.get('PROJECT_NAME') or 'flint-cloud'
-os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = 'flint-cloud-81ab3d7821f5.json'
+with open('service_account.json', 'w') as saf:
+    saf.write(os.environ.get('SERVICE_ACCOUNT') or 'ERROR')
+os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = 'service_account.json'
 publisher = pubsub_v1.PublisherClient()
 
 

--- a/layered/cloud-run/main.py
+++ b/layered/cloud-run/main.py
@@ -14,12 +14,12 @@ from google.api_core.exceptions import AlreadyExists
 
 app = Flask(__name__)
 
+project = os.environ.get('PROJECT_NAME') or 'flint-cloud'
 os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = 'flint-cloud-81ab3d7821f5.json'
 publisher = pubsub_v1.PublisherClient()
-project = 'flint-cloud'
 
 
-def create_topic(name, project='flint-cloud'):
+def create_topic(name, project=project):
     """Create topic in the given project and subscribe to it. Returns subscription path"""
     topic_path = publisher.topic_path(project, name)
     try:
@@ -28,7 +28,7 @@ def create_topic(name, project='flint-cloud'):
         pass
 
 
-def publish_message(topic, attribs, project='flint-cloud'):
+def publish_message(topic, attribs, project=project):
     """Publish message in given topic"""
     msg = json.dumps(attribs).encode('utf-8')
     topic_path = publisher.topic_path(project, topic)

--- a/layered/compute-engine/main.py
+++ b/layered/compute-engine/main.py
@@ -10,10 +10,11 @@ from google.api_core import retry
 from google.api_core.exceptions import AlreadyExists
 from googleapiclient import discovery
 
-
+project = os.environ.get('PROJECT_NAME') or 'flint-cloud'
+zone = os.environ.get('GCE_ZONE') or 'us-central1-a'
+instance = os.environ.get('GCE_NAME') or 'instance-1'
 os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = 'flint-cloud-baec10f8dd27.json'
 publisher = pubsub_v1.PublisherClient()
-project = 'flint-cloud'
 
 
 def create_topic(name, project='flint-cloud'):
@@ -215,10 +216,6 @@ def process(data):
 def shutdown():
     """Stop GCE instance"""
     service = discovery.build('compute', 'v1')
-
-    project = 'flint-cloud'
-    zone = 'us-central1-a'
-    instance = 'instance-1'
 
     request = service.instances().stop(project=project, zone=zone, instance=instance)
     response = request.execute()

--- a/layered/compute-engine/main.py
+++ b/layered/compute-engine/main.py
@@ -13,7 +13,9 @@ from googleapiclient import discovery
 project = os.environ.get('PROJECT_NAME') or 'flint-cloud'
 zone = os.environ.get('GCE_ZONE') or 'us-central1-a'
 instance = os.environ.get('GCE_NAME') or 'instance-1'
-os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = 'flint-cloud-baec10f8dd27.json'
+with open('service_account.json', 'w') as saf:
+    saf.write(os.environ.get('SERVICE_ACCOUNT') or 'ERROR')
+os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = 'service_account.json'
 publisher = pubsub_v1.PublisherClient()
 
 

--- a/layered/ingress/main.py
+++ b/layered/ingress/main.py
@@ -15,7 +15,9 @@ app = Flask(__name__)
 project = os.environ.get('PROJECT_NAME') or 'flint-cloud'
 zone = os.environ.get('GCE_ZONE') or 'us-central1-a'
 instance = os.environ.get('GCE_NAME') or 'instance-1'
-os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = 'flint-cloud-baec10f8dd27.json'
+with open('service_account.json', 'w') as saf:
+    saf.write(os.environ.get('SERVICE_ACCOUNT') or 'ERROR')
+os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = 'service_account.json'
 publisher = pubsub_v1.PublisherClient()
 
 

--- a/layered/ingress/main.py
+++ b/layered/ingress/main.py
@@ -12,11 +12,14 @@ from estimate_run_size import SimulationSize, estimate_simulation_size
 
 app = Flask(__name__)
 
+project = os.environ.get('PROJECT_NAME') or 'flint-cloud'
+zone = os.environ.get('GCE_ZONE') or 'us-central1-a'
+instance = os.environ.get('GCE_NAME') or 'instance-1'
 os.environ['GOOGLE_APPLICATION_CREDENTIALS'] = 'flint-cloud-baec10f8dd27.json'
 publisher = pubsub_v1.PublisherClient()
 
 
-def create_topic(name, project='flint-cloud'):
+def create_topic(name, project=project):
     """Create topic in the given project and subscribe to it. Returns subscription path"""
     topic_path = publisher.topic_path(project, name)
     try:
@@ -25,7 +28,7 @@ def create_topic(name, project='flint-cloud'):
         pass
 
 
-def create_sub(name, project='flint-cloud'):
+def create_sub(name, project=project):
     topic_path = publisher.topic_path(project, name)
     subscriber = pubsub_v1.SubscriberClient()
     subscription_path = subscriber.subscription_path(project, f'{name}-sub')
@@ -39,7 +42,7 @@ def create_sub(name, project='flint-cloud'):
     return subscription_path
 
 
-def publish_message(topic, data, project='flint-cloud'):
+def publish_message(topic, data, project=project):
     """Publish message in given topic"""
     create_topic(topic)
     msg = json.dumps(data).encode('utf-8')
@@ -260,10 +263,6 @@ def small_run(data):
 def large_run(data):
     """Start GCE instance and publish  message for large run on Pub/Sub"""
     service = discovery.build('compute', 'v1')
-
-    project = 'flint-cloud'
-    zone = 'us-central1-a'
-    instance = 'instance-1'
 
     request = service.instances().start(project=project, zone=zone, instance=instance)
     response = request.execute()

--- a/layered/main.tf
+++ b/layered/main.tf
@@ -211,6 +211,7 @@ resource "google_pubsub_subscription" "small-simulations-sub" {
 resource "google_storage_bucket" "simulation_data_flint-cloud" {
   name = "simulation_data_flint-cloud"
   location = var.region
+  force_destroy = true
 
   depends_on = [google_project_service.storage]
 }
@@ -287,7 +288,7 @@ resource "google_compute_instance" "fc-gce-processor" {
 
   scheduling {
     automatic_restart = false
-    preemptible = true
+    preemptible = false
   }
 
   service_account {

--- a/layered/main.tf
+++ b/layered/main.tf
@@ -217,6 +217,14 @@ resource "google_storage_bucket" "simulation_data_flint-cloud" {
 }
 
 # Compute Engine processor
+resource "google_pubsub_subscription" "large-simulations-sub" {
+  name  = "large-simulations-sub"
+  topic = google_pubsub_topic.large-simulations.name
+  ack_deadline_seconds = 10
+
+  depends_on = [google_pubsub_topic.large-simulations]
+}
+
 module "gce-container" {
   source = "terraform-google-modules/container-vm/google"
   version = "~> 2.0"
@@ -296,5 +304,5 @@ resource "google_compute_instance" "fc-gce-processor" {
     scopes = ["cloud-platform"]
   }
 
-  depends_on = [google_project_service.compute, google_pubsub_topic.large-simulations, google_service_account.gce-sa]
+  depends_on = [google_project_service.compute, google_pubsub_subscription.large-simulations-sub, google_service_account.gce-sa]
 }

--- a/layered/main.tf
+++ b/layered/main.tf
@@ -1,0 +1,299 @@
+# Modifiable variables
+variable "project" {
+  type = string
+  default = "flint-cloud"
+}
+
+variable "region" {
+  type = string
+  default = "us-central1"
+}
+
+variable "zone" {
+  type = string
+  default = "us-central1-a"
+}
+
+variable "ingress_name" {
+  type = string
+  default = "fc-ingress"
+}
+
+variable "cr_processor_name" {
+  type = string
+  default = "fc-cr-processor"
+}
+
+variable "gce_processor_name" {
+  type = string
+  default = "fc-gce-processor"
+}
+
+variable "gce_processor_cpu" {
+  type = number
+  default = 4
+}
+
+variable "gce_processor_memory" {
+  type = number
+  default = 10240
+}
+
+variable "gce_processor_disk" {
+  type = number
+  default = 15
+}
+
+# Project config
+provider "google" {
+  credentials = file("service_account.json")
+  project = var.project
+  region = var.region
+}
+
+# Enable APIs
+resource "google_project_service" "run" {
+  service = "run.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "pubsub" {
+  service = "pubsub.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "storage" {
+  service = "storage-component.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "compute" {
+  service = "compute.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "iam" {
+  service = "iam.googleapis.com"
+  disable_on_destroy = false
+}
+
+# Pub/Sub Topics
+resource "google_pubsub_topic" "small-simulations" {
+  name = "small-simulations"
+
+  depends_on = [google_project_service.pubsub]
+}
+
+resource "google_pubsub_topic" "large-simulations" {
+  name = "large-simulations"
+
+  depends_on = [google_project_service.pubsub]
+}
+
+# Ingress service
+resource "google_cloud_run_service" "fc-ingress" {
+  name = var.ingress_name
+  location = var.region
+  
+  template {
+    spec {
+      containers {
+        image = "gcr.io/flint-cloud/ingress:latest"
+        env {
+          name = "PROJECT_NAME"
+          value = var.project
+        }
+        env {
+          name = "GCE_ZONE"
+          value = var.zone
+        }
+        env {
+          name = "GCE_NAME"
+          value = var.gce_processor_name
+        }
+      }
+    }
+  }
+
+  traffic {
+    percent = 100
+    latest_revision = true
+  }
+  autogenerate_revision_name = true
+  depends_on = [google_project_service.run]
+}
+
+output "ingress-url" {
+  value = "${google_cloud_run_service.fc-ingress.status[0].url}"
+}
+
+data "google_iam_policy" "noauth-ingress" {
+  binding {
+    role = "roles/run.invoker"
+    members = [
+      "allUsers",
+    ]
+  }
+}
+
+resource "google_cloud_run_service_iam_policy" "noauth-ingress" {
+  location    = var.region
+  project     = var.project
+  service     = google_cloud_run_service.fc-ingress.name
+  policy_data = data.google_iam_policy.noauth-ingress.policy_data
+}
+
+# Cloud Run processor
+resource "google_cloud_run_service" "fc-cr-processor" {
+  name = var.cr_processor_name
+  location = var.region
+  
+  template {
+    spec {
+      containers {
+        image = "gcr.io/flint-cloud/cr-processor:latest"
+        resources {
+          limits = {
+            cpu    = "4000m"
+            memory = "2Gi"
+          }
+        }
+        env {
+          name = "LD_LIBRARY_PATH"
+          value = "/opt/gcbm:/usr/local//lib:/usr/local//lib/x86_64-linux-gnu:/usr/local/lib:/usr/local/lib/x86_64-linux-gnu:/usr/local/lib:"
+        }
+        env {
+          name = "PROJECT_NAME"
+          value = var.project
+        }
+      }
+      timeout_seconds = 3599
+    }
+  }
+
+  traffic {
+    percent = 100
+    latest_revision = true
+  }
+  autogenerate_revision_name = true
+  depends_on = [google_project_service.run]
+}
+
+data "google_iam_policy" "noauth-cr-processor" {
+  binding {
+    role = "roles/run.invoker"
+    members = [
+      "allUsers",
+    ]
+  }
+}
+
+resource "google_cloud_run_service_iam_policy" "noauth-cr-processor" {
+  location    = var.region
+  project     = var.project
+  service     = google_cloud_run_service.fc-cr-processor.name
+  policy_data = data.google_iam_policy.noauth-cr-processor.policy_data
+}
+
+resource "google_pubsub_subscription" "small-simulations-sub" {
+  name  = "small-simulations-sub"
+  topic = google_pubsub_topic.small-simulations.name
+  ack_deadline_seconds = 10
+
+  push_config {
+    push_endpoint = "${google_cloud_run_service.fc-cr-processor.status[0].url}"
+  }
+
+  depends_on = [google_pubsub_topic.small-simulations, google_cloud_run_service.fc-cr-processor]
+}
+
+# GCS bucket
+resource "google_storage_bucket" "simulation_data_flint-cloud" {
+  name = "simulation_data_flint-cloud"
+  location = var.region
+
+  depends_on = [google_project_service.storage]
+}
+
+# Compute Engine processor
+module "gce-container" {
+  source = "terraform-google-modules/container-vm/google"
+  version = "~> 2.0"
+
+  container = {
+    image = "gcr.io/flint-cloud/gce-processor:latest"
+    securityContext = {
+      privileged : true
+    }
+    env = [
+      {
+        name = "PROJECT_NAME"
+        value = var.project
+      },
+      {
+        name = "GCE_ZONE"
+        value = var.zone
+      },
+      {
+        name = "GCE_NAME"
+        value = var.gce_processor_name
+      }
+    ]
+  }
+
+  restart_policy = "OnFailure"
+}
+
+resource "google_service_account" "gce-sa" {
+  account_id   = "fc-gce-processor-service"
+  display_name = "FLINT Cloud GCE Service Account"
+  project = var.project
+
+  depends_on = [google_project_service.iam]
+}
+
+resource "google_project_iam_member" "gce-sa-binding" {
+  project = var.project
+  role    = "roles/storage.objectViewer"
+  member  = "serviceAccount:${google_service_account.gce-sa.email}"
+
+  depends_on = [google_service_account.gce-sa]
+}
+
+resource "google_compute_instance" "fc-gce-processor" {
+  name = var.gce_processor_name
+  project = var.project
+  machine_type = "custom-${var.gce_processor_cpu}-${var.gce_processor_memory}"
+  zone = var.zone
+
+  boot_disk {
+    initialize_params {
+      image = module.gce-container.source_image
+      size = var.gce_processor_disk
+    }
+  }
+
+  network_interface {
+    network = "default"
+    subnetwork = "default"
+    access_config {}
+  }
+
+  metadata = {
+    gce-container-declaration = module.gce-container.metadata_value
+    google-logging-enabled = "true"
+    google-monitoring-enabled = "true"
+  }
+
+  scheduling {
+    automatic_restart = false
+    preemptible = true
+  }
+
+  service_account {
+    email  = google_service_account.gce-sa.email
+    scopes = ["cloud-platform"]
+  }
+
+  depends_on = [google_project_service.compute, google_pubsub_topic.large-simulations, google_service_account.gce-sa]
+}


### PR DESCRIPTION
This pull request adds a Terraform script to allow users to deploy FLINT Cloud (layered) in their own GCP projects. The Terraform script allows provisioning or destruction of all FLINT Cloud resources with a single command.

## Usage
### Deploying FLINT Cloud
1. Create a service account with project owner permissions in your project. This is used by Terraform to provision all the necessary resources.
2. Copy `main.tf` from the `layered` directory of this repository to your Cloud Console machine.
3. In `main.tf`, change the `project` variable to your project ID. Change any other variables if necessary. 
4. Download the key for the service account created in step 1 (in JSON format) to your project's Cloud Console machine. Rename it as `service_account.json`.
5. Run `terraform apply`. After this command finishes, it should output the URL to FLINT Cloud (ingress).

### Destroying FLINT Cloud
1. In the same directory as where `main.tf` is present, run `terraform destroy`.   
