### PR TITLE
Add instructions for layered + minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,20 @@
 
 The project aims to build a continuous deployment pipeline to offer FLINT as a SaaS over cloud. The project also aims to simplify the process of installation by supporting a single command or step installation process.
 
+### Layered Architecture Setup on Google Cloud
+
+#### Deploying
+
+1. Create a service account with project owner permissions in your project. This is used by Terraform to provision all the necessary resources.
+2. Copy `main.tf` from the `layered` directory of this repository to your Cloud Console machine.
+3. In `main.tf`, change the `project` variable to your project ID. Change any other variables if necessary. 
+4. Download the key for the service account created in step 1 (in JSON format) to your project's Cloud Console machine. Rename it as `service_account.json`.
+5. Run `terraform apply`. After this command finishes, it should output the URL to FLINT Cloud (ingress).
+
+#### Disabling
+
+1. In the same directory as where `main.tf` is present, run `terraform destroy`.   
+
 ### Flask.example REST API Setup  
 
 In order to run the REST API, please follow the following steps: - 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The project aims to build a continuous deployment pipeline to offer FLINT as a S
 
 #### Disabling
 
-1. In the same directory as where `main.tf` is present, run `terraform destroy`.   
+1. In the same directory as where `main.tf` is present, run `terraform destroy`. In case this fails, simply run it again.     
 
 ### Flask.example REST API Setup  
 

--- a/layered/cloud-run/main.py
+++ b/layered/cloud-run/main.py
@@ -232,7 +232,7 @@ def index():
         }
         logging.info(response)
         publish_message(topic_name, response)
-        cleanup(subscription_path)
+        # cleanup(subscription_path)
 
     return '', 204
 

--- a/layered/cloud-run/main.py
+++ b/layered/cloud-run/main.py
@@ -58,6 +58,27 @@ def upload_blob(title, source_file_name):
     )
 
 
+def delete_blob(title, source_file_name):
+    """Deletes a file to from the bucket."""
+    # The ID of your GCS bucket
+    bucket_name = "simulation_data_flint-cloud"
+    # The path to your file to upload
+    #source_file_name = "local/path/to/file"
+    # The ID of your GCS object
+    destination_blob_name = "simulations/simulation-"+title+"/"+source_file_name
+
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(destination_blob_name)
+
+    blob.delete()
+
+    logging.debug(
+        "Deleted %s.",
+        destination_blob_name
+    )
+
+
 def download_blob(title, source_blob_name):
     """Downloads a file from the bucket."""
     # The ID of your GCS bucket
@@ -120,21 +141,25 @@ def generate_download_signed_url_v4(project_dir):
     return url
 
 
-def cleanup(subscription_path):
-    subscriber = pubsub_v1.SubscriberClient()
-    with subscriber:
-        response = subscriber.pull(
-            request={'subscription': subscription_path, 'max_messages': 25},
-            retry=retry.Retry(deadline=15),
-        )
-        if len(response.received_messages) > 0:
-            # Simulation already started/finished, exit
-            ack_ids = []
-            for msg in response.received_messages:
-                ack_ids.append(msg.ack_id)
-            subscriber.acknowledge(
-                request={'subscription': subscription_path, 'ack_ids': ack_ids}
-            )
+def create_log(title):
+    """Create log file"""
+    with open('log.txt', 'w+') as lf:
+        lf.write(time.ctime() + '\n')
+    upload_blob(title, 'log.txt')
+
+
+def check_log(title):
+    """Check for log"""
+    storage_client = storage.Client()
+    bucket_name = 'simulation_data_flint-cloud'
+    bucket = storage_client.bucket(bucket_name)
+    blob_path = f'simulations/simulation-{title}/log.txt'
+    return storage.Blob(bucket=bucket, name=blob_path).exists(storage_client)
+
+
+def cleanup_log(title):
+    """Erase log file"""
+    delete_blob(title, 'log.txt')
 
 
 @app.route('/', methods=['POST'])
@@ -158,38 +183,18 @@ def index():
         topic_name = data['topic']
         topic_path = publisher.topic_path(project, topic_name)
         title = data['title']
-        subscription_path = f"{data['subscription']}-internal"
-
-        internal_topic_name = f'{topic_name}-internal'
-        internal_topic_path = publisher.topic_path(
-            project, internal_topic_name)
-        create_topic(internal_topic_name)
 
         # Exit if input exists already
         if os.path.exists(f'/input/{title}'):
             return '', 204
 
-        subscriber = pubsub_v1.SubscriberClient()
-        with subscriber:
-            try:
-                subscription = subscriber.create_subscription(
-                    request={'name': subscription_path,
-                             'topic': internal_topic_path}
-                )
-            except AlreadyExists:
-                pass
-            response = subscriber.pull(
-                request={'subscription': subscription_path, 'max_messages': 1},
-                retry=retry.Retry(deadline=10),
-            )
-            if len(response.received_messages) > 0:
-                # Simulation already started/finished, ack trigger message and exit
-                return '', 204
+        if check_log(title):
+            return '', 204
+        create_log(title)
 
         # Publish info message
         info_msg = {'message': 'Simulation started'}
         publish_message(topic_name, info_msg)
-        publish_message(internal_topic_name, info_msg)
 
         # download input from bucket
         download_blob(title, 'input.zip')
@@ -232,7 +237,7 @@ def index():
         }
         logging.info(response)
         publish_message(topic_name, response)
-        # cleanup(subscription_path)
+        cleanup_log(title)
 
     return '', 204
 

--- a/layered/compute-engine/main.py
+++ b/layered/compute-engine/main.py
@@ -36,6 +36,27 @@ def publish_message(topic, attribs, project='flint-cloud'):
     return publisher.publish(topic_path, msg)
 
 
+def delete_blob(title, source_file_name):
+    """Deletes a file to from the bucket."""
+    # The ID of your GCS bucket
+    bucket_name = "simulation_data_flint-cloud"
+    # The path to your file to upload
+    #source_file_name = "local/path/to/file"
+    # The ID of your GCS object
+    destination_blob_name = "simulations/simulation-"+title+"/"+source_file_name
+
+    storage_client = storage.Client()
+    bucket = storage_client.bucket(bucket_name)
+    blob = bucket.blob(destination_blob_name)
+
+    blob.delete()
+
+    logging.debug(
+        "Deleted %s.",
+        destination_blob_name
+    )
+
+
 def upload_blob(title, source_file_name):
     """Uploads a file to the bucket."""
     # The ID of your GCS bucket
@@ -119,58 +140,43 @@ def generate_download_signed_url_v4(project_dir):
     return url
 
 
-def cleanup(subscription_path):
-    subscriber = pubsub_v1.SubscriberClient()
-    with subscriber:
-        response = subscriber.pull(
-            request={'subscription': subscription_path, 'max_messages': 25},
-            retry=retry.Retry(deadline=15),
-        )
-        if len(response.received_messages) > 0:
-            # Simulation already started/finished, exit
-            ack_ids = []
-            for msg in response.received_messages:
-                ack_ids.append(msg.ack_id)
-            subscriber.acknowledge(
-                request={'subscription': subscription_path, 'ack_ids': ack_ids}
-            )
+def create_log(title):
+    """Create log file"""
+    with open('log.txt', 'w+') as lf:
+        lf.write(time.ctime() + '\n')
+    upload_blob(title, 'log.txt')
+
+
+def check_log(title):
+    """Check for log"""
+    storage_client = storage.Client()
+    bucket_name = 'simulation_data_flint-cloud'
+    bucket = storage_client.bucket(bucket_name)
+    blob_path = f'simulations/simulation-{title}/log.txt'
+    return storage.Blob(bucket=bucket, name=blob_path).exists(storage_client)
+
+
+def cleanup_log(title):
+    """Erase log file"""
+    delete_blob(title, 'log.txt')
 
 
 def process(data):
     topic_name = data['topic']
     topic_path = publisher.topic_path(project, topic_name)
     title = data['title']
-    subscription_path = f"{data['subscription']}-internal"
-
-    internal_topic_name = f'{topic_name}-internal'
-    internal_topic_path = publisher.topic_path(project, internal_topic_name)
-    create_topic(internal_topic_name)
 
     # Exit if input exists already
     if os.path.exists(f'/input/{title}'):
         return
 
-    subscriber = pubsub_v1.SubscriberClient()
-    with subscriber:
-        try:
-            subscription = subscriber.create_subscription(
-                request={'name': subscription_path,
-                         'topic': internal_topic_path}
-            )
-        except AlreadyExists:
-            pass
-        response = subscriber.pull(
-            request={'subscription': subscription_path, 'max_messages': 1},
-            retry=retry.Retry(deadline=10),
-        )
-        if len(response.received_messages) > 0:
-            # Simulation already started/finished, exit
-            return
+    if check_log(title):
+        return
+    create_log(title)
 
     # Publish info message
     info_msg = {'message': 'Simulation started'}
     publish_message(topic_name, info_msg)
-    publish_message(internal_topic_name, info_msg)
 
     # download input from bucket
     download_blob(title, 'input.zip')
@@ -213,7 +219,7 @@ def process(data):
     }
     logging.info(response)
     publish_message(topic_name, response)
-    cleanup(subscription_path)
+    cleanup_log(title)
 
 
 def shutdown():

--- a/layered/main.tf
+++ b/layered/main.tf
@@ -215,6 +215,7 @@ resource "google_cloud_run_service" "fc-cr-processor" {
         }
       }
       timeout_seconds = 3599
+      container_concurrency = 1
     }
   }
 


### PR DESCRIPTION
- Added setup instructions for layered architecture
- Limit cloud run processor's concurrency to 1. Two medium runs on the same instance can possibly timeout.
- Improved queueing algorithm for compute engine instance (handles duplicates)
- Create a temporary run log file to record the start time 