### PR TITLE
Fix CORS errors in FLINT Example REST API

### DIFF
--- a/rest_api_flint.example/app.py
+++ b/rest_api_flint.example/app.py
@@ -7,9 +7,12 @@ import json
 from datetime import datetime
 from flask_swagger import swagger
 from flask_swagger_ui import get_swaggerui_blueprint
+from flask_cors import CORS
 
 app = Flask(__name__)
+CORS(app, origins=[ 'http://127.0.0.1:8080/','http://127.0.0.1:8000','http://localhost:5000',r'^https://.+example.com$'])
 api = Api(app)
+
 
 ### swagger specific ###
 SWAGGER_URL = '/swagger'

--- a/rest_api_flint.example/requirements.txt
+++ b/rest_api_flint.example/requirements.txt
@@ -3,3 +3,4 @@ flask-restful
 gunicorn
 flask-swagger
 flask_swagger_ui
+flask-cors


### PR DESCRIPTION
Adds support to enable CORS in FLINT Example REST API and fixes #19.