### PR TITLE
Removed unnecessary else used after return

### DIFF
--- a/layered/ingress/main.py
+++ b/layered/ingress/main.py
@@ -132,7 +132,6 @@ def gcbm_new():
         return {
             "data": "New simulation started. Please move on to the next stage for uploading files at /gcbm/upload."
         }, 200
-    else:
         return {
             "data": "Simulation already exists. Please check the list of simulations present before proceeding with a new simulation at gcbm/list. You may also download the input and output files for this simulation at gcbm/download sending parameter title in the body."
         }, 400

--- a/rest_api_flint.example/app.py
+++ b/rest_api_flint.example/app.py
@@ -196,4 +196,4 @@ def rothc():
 
 
 if __name__ == "__main__":
-    app.run(debug=True, host="0.0.0.0", port=int(os.environ.get("PORT", 8080)))
+    app.run(debug=True, host="127.0.0.1", port=int(os.environ.get("PORT", 8080)))

--- a/rest_api_flint.example/app.py
+++ b/rest_api_flint.example/app.py
@@ -196,4 +196,4 @@ def rothc():
 
 
 if __name__ == "__main__":
-    app.run(debug=True, host="127.0.0.1", port=int(os.environ.get("PORT", 8080)))
+    app.run(debug=True, host="0.0.0.0", port=int(os.environ.get("PORT", 8080)))

--- a/rest_api_gcbm/app.py
+++ b/rest_api_gcbm/app.py
@@ -265,7 +265,6 @@ def gcbm_new():
         return {
             "data": "New simulation started. Please move on to the next stage for uploading files at /gcbm/upload."
         }, 200
-    else:
         return {
             "data": "Simulation already exists. Please check the list of simulations present before proceeding with a new simulation at gcbm/list. You may also download the input and output files for this simulation at gcbm/download sending parameter title in the body."
         }, 400


### PR DESCRIPTION
## Description

`return` statement causes the control flow to be disrupted, making the `else` block here unnecessary. This doesn't mean we can not use it, but it is recommended to refactor this for better readability.
