### PR TITLE
Remove ENV port and make changes to CMD.

### DIFF
--- a/rest_api_flint.example/Dockerfile
+++ b/rest_api_flint.example/Dockerfile
@@ -10,8 +10,7 @@ RUN set -xe \
 RUN pip install --no-cache-dir --upgrade pip
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
-ENV PORT 8080
 
 COPY . .
 
-CMD ["exec", "gunicorn", "--bind", ":$PORT", "--workers", "1", "--threads", "8", "--timeout", "0", "app:app"]
+CMD ["gunicorn", "--bind", ":$PORT", "--workers", "1", "--threads", "8", "--timeout", "0", "app:app"]

--- a/rest_api_gcbm/Dockerfile
+++ b/rest_api_gcbm/Dockerfile
@@ -12,8 +12,7 @@ RUN set -xe \
 RUN pip install --no-cache-dir --upgrade pip
 COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
-ENV PORT 8080
 
 COPY . .
 
-CMD ["exec", "gunicorn", "--bind", ":$PORT", "--workers", "1", "--threads", "8", "--timeout", "0", "app:app"]
+CMD ["gunicorn", "--bind", ":$PORT", "--workers", "1", "--threads", "8", "--timeout", "0", "app:app"]


### PR DESCRIPTION
## Description

Make Changes to the docker file of the `rest-api-gcbm` and `rest-api-flint.example`. The changes run the container successfully after building the image. 

- [x] Bug fix (non-breaking change which fixes an issue)


