### PR TITLE
fix: Update `FLINT.Example` image location to GitHub container registry

### DIFF
--- a/local/rest_api_flint.example/Dockerfile
+++ b/local/rest_api_flint.example/Dockerfile
@@ -1,5 +1,5 @@
 #FROM mojaglobal/flint
-FROM shubhamkarande13/flint.example:bionic
+FROM ghcr.io/moja-global/flint.example:master
 
 #ENV APP_HOME /app
 WORKDIR /server


### PR DESCRIPTION
Related: moja-global/FLINT-UI#71
