### PR TITLE
Add python dependencies for GCBM post-processing

### DIFF
--- a/local/rest_api_gcbm/requirements.txt
+++ b/local/rest_api_gcbm/requirements.txt
@@ -7,3 +7,7 @@ flask_autoindex
 google-cloud-storage
 google-cloud-pubsub
 flask-cors
+
+simplejson
+sqlalchemy
+psutil


### PR DESCRIPTION
## Description

I've been running the GCBMCompileResults tools found in GCBM.Belize and found these missing packages. They're useful in most GCBM workflows so I think they should go in the FLINTcloud containers.