### PR TITLE
Add pandas and matplotlib to requirements

### DIFF
--- a/local/rest_api_gcbm/requirements.txt
+++ b/local/rest_api_gcbm/requirements.txt
@@ -11,3 +11,5 @@ flask-cors
 simplejson
 sqlalchemy
 psutil
+pandas
+matplotlib


### PR DESCRIPTION
This PR adds `pandas` and `matplotlib` to requirements which will be needed for the CML workflow.