### PR TITLE
Publish separate GCBM build under flint.gcbm

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -58,7 +58,7 @@ jobs:
     permissions:
       contents: read
       packages: write
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -84,6 +84,45 @@ jobs:
         with:
           context: ./docker
           file: "./docker/Dockerfile.flint"
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  publish-gcbm-image:
+    name: Build FLINT
+    needs: publish-base-image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        uses: docker/login-action@28218f9b04b4f3f62068d7b6ce6ca5b26e35336c
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@98669ae865ea3cffbcbaa878cf57c20bbf1c6c38
+        with:
+          images: ${{ env.REGISTRY }}/moja-global/flint.gbcm
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@ad44023a93711e3deb337508980b4b5e9bcdc5dc
+        with:
+          context: ./docker
+          file: "./docker/Dockerfile.gcbm"
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/docker/Dockerfile.gcbm
+++ b/docker/Dockerfile.gcbm
@@ -1,0 +1,34 @@
+FROM ghcr.io/moja-global/flint.core:master
+
+WORKDIR $ROOTDIR/src
+
+# moja.canada requires libpqxx.
+RUN git clone --recursive https://github.com/jtv/libpqxx.git \
+    && mkdir libpqxx/build \
+    && cd libpqxx/build \
+    && cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+            -DCMAKE_INSTALL_PREFIX=/usr/local \
+            -DSKIP_BUILD_TEST=ON \
+            -FSKIP_PQXX_STATIC=ON .. \
+            -DCMAKE_CXX_FLAGS=-fPIC \
+            -DPostgreSQL_TYPE_INCLUDE_DIR=/usr/include/postgresql \
+    && make --quiet -j $NUM_CPU install/strip \
+    && make clean \
+    && cd $ROOTDIR/src
+
+# moja.canada
+RUN git clone -b develop https://github.com/moja-global/moja.canada \
+    && mkdir -p moja.canada/Source/build \
+    && cd moja.canada/Source/build \
+    && cmake -DCMAKE_BUILD_TYPE=$BUILD_TYPE \
+            -DCMAKE_INSTALL_PREFIX=$ROOTDIR \
+            -DENABLE_TESTS:BOOL=OFF \
+            -DPostgreSQL_TYPE_INCLUDE_DIR=/usr/include/postgresql .. \
+    && make --quiet -s -j $NUM_CPU \
+    && make --quiet install \
+    && make clean \
+    && cd $ROOTDIR/src
+
+RUN mkdir -p /opt/gcbm
+RUN ln -t /opt/gcbm /usr/local/lib/lib*
+RUN ln -t /opt/gcbm /usr/local/bin/moja.cli

--- a/local/rest_api_gcbm/Dockerfile
+++ b/local/rest_api_gcbm/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/moja-global/moja.canada:develop
+FROM ghcr.io/moja-global/flint.gcbm:master
 
 WORKDIR /app
 


### PR DESCRIPTION
### Description
Hopefully closes #106 

For whatever reason, there are minor differences between the image built here and at [moja.canada](https://github.com/moja-global/moja.canada). I have tested against the [GCBM.Belize](https://github.com/moja-global/GCBM.Belize) project with success.

Edit: I forgot, GCBM.Belize has windows format file names in `config`. If testing, please switch to the `gcbm-container` branch.

### Steps to reproduce
```sh
docker run -it -v ~/GCBM.Belize/Standalone_Project:/server ghcr.io/moja-global/moja.canada:develop
cd /server/gcbm_project
/opt/gcbm/moja.cli --config_file gcbm_config.cfg --config_provider provider_config.json

# <2022-05-07 03:10:53.395894> (fatal) - startup(1403) - Exception caught at LocalDomain level, exiting. | Library: moja.modules.cbm | Module: CBMLandClassTransitionModule | Details: Bad cast exception


docker build -f FLINT.cloud/docker/Dockerfile.gcbm -t flint.gcbm .
docker run -it -v ~/GCBM.Belize/Standalone_Project:/server flint.gcbm
cd /server/gcbm_project
/opt/gcbm/moja.cli --config_file gcbm_config.cfg --config_provider provider_config.json

# <2022-05-07 03:13:13.306299> (info) - 103: Stats level [Block]: Record [  793 of   800]: Index [( 26730,  7)]: Time(ms) [Total:    21940, Processed:     3905]: Units [Total:      100, Processed:       30, NotProcessed:       70, Errors:        0, LU/second:        4]
...
```

### Description of the bug
@HarshCasper - I can only assume there's a small incompatibility between `ghcr.io/moja-global/flint.core:master` and the previous image used before we switched. I suspect this is probably because we moved some of the Poco configuration that is specified in `moja.canada/Dockerfile` into `FLINT.cloud/docker/Dockerfile.flint`.

### Next steps
Because we don't know how the `moja.canada/Dockerfile` is used, I think we should probably revert the change in [#29](https://github.com/moja-global/moja.canada/pull/29/files) and publish a separate image from the FLINTcloud CI, with the proposed name `flint.gcbm`. 

This would allow @mfellows to define his own build, without needing to coordinate with the rest of the FLINTcloud dependencies. Very keen to hear your thoughts - we can think about whether to continue to publish the `moja.canda` image.

I'm not super familiar with GitHub Actions so can you please double check the workflow changes closely?
