### PR TITLE
Fix names of Github Actions build stages

### DIFF
--- a/.github/workflows/base.yml
+++ b/.github/workflows/base.yml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   publish-base-image:
-    name: Build base images for FLINT
+    name: Build base images
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -93,7 +93,7 @@ jobs:
           cache-to: type=gha,mode=max
 
   publish-gcbm-image:
-    name: Build FLINT
+    name: Build GCBM
     needs: publish-flint-image
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
Fixes naming shown here: https://github.com/moja-global/FLINT.Cloud/actions/runs/2365459825