### PR TITLE
feat: create a script to obtain the status of the simulation

### DIFF
--- a/local/tests/simulation_status.py
+++ b/local/tests/simulation_status.py
@@ -28,7 +28,7 @@ def get_simulation_status():
         logs = []
         with open(logs_file_name) as file_handle:
             logs = file_handle.readlines()
-        os.system('rm ' + logs_file_name)
+        #os.system('rm ' + logs_file_name)
         return {'container_running': True, 'logs': logs}
     return {'container_running': False}
 

--- a/local/tests/simulation_status.py
+++ b/local/tests/simulation_status.py
@@ -1,0 +1,35 @@
+import os
+
+
+def get_container_id():
+    """
+      Return the container id corresponding to the image gcbm-api
+    """
+    container_id = "" 
+    os.system('docker ps >> simulation.txt')
+    with open('simulation.txt') as file_handle:
+        lines = file_handle.readlines()
+        for line in lines:
+            if 'gcbm-api' in line:
+                container_id = line.split()[0]
+    os.system('rm simulation.txt')
+    return container_id
+
+  
+def get_simulation_status():
+    """
+      If the container gcbm-api is running, the associated logs are returned
+    """
+    container_id = get_container_id()
+    logs_file_name = container_id + ".txt"
+    if container_id != '':
+        logs_cmd = "docker logs " + container_id + " > " + logs_file_name +  " 2>&1"
+        os.system(logs_cmd)
+        logs = []
+        with open(logs_file_name) as file_handle:
+            logs = file_handle.readlines()
+        os.system('rm ' + logs_file_name)
+        return {'container_running': True, 'logs': logs}
+    return {'container_running': False}
+
+print(get_simulation_status())


### PR DESCRIPTION
# Pull Request Template

## Description

The existing endpoints for the gcbm example do not report a failure in the simulation.
The script `simulation-status.py` returns the logs of the docker container (if it is running).
This can be used in the process of automated testing

To obtain the logs of the simulation : 

1. Start the simulation
2. Run the script `simulation-status.py` , a text file containing the logs will be created


Fixes #93 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
