### PR TITLE
fix: prevent cors issue for host as `localhost`

### DIFF
--- a/local/rest_api_flint.example/app.py
+++ b/local/rest_api_flint.example/app.py
@@ -16,6 +16,7 @@ CORS(
     origins=[
         "http://127.0.0.1:8080/",
         "http://127.0.0.1:8000",
+        "http://localhost:8000",
         "http://localhost:5000",
         r"^https://.+example.com$",
     ],


### PR DESCRIPTION

The change prevents the cors issue in the case when the user hits from `localhost:8000` instead of `127.0.0.1:8000`

Fixes/Addresses #119

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?


## Additional Context (Please include any Screenshots/gifs if relevant)

...

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [x] I have checked my code and corrected any misspellings
- [ ] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [ ] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
