### PR TITLE
Renamed the endpoint dynamic to run

### DIFF
--- a/local/rest_api_gcbm/app.py
+++ b/local/rest_api_gcbm/app.py
@@ -229,7 +229,7 @@ def gcbm_upload():
     get_provider_config(input_dir)
 
     return {
-        "data": "All files uploaded succesfully. Proceed to the next step of the API at gcbm/dynamic."
+        "data": "All files uploaded succesfully. Proceed to the next step of the API at gcbm/run"
     }
 
 
@@ -599,8 +599,8 @@ def config_table():
         return {"status": 0, "error": Exception}
 
 
-@app.route("/gcbm/dynamic", methods=["POST"])
-def gcbm_dynamic():
+@app.route("/gcbm/run", methods=["POST"])
+def gcbm_run():
     """
     Get GCBM Dynamic implementation of FLINT
     ---

--- a/local/rest_api_gcbm/curl.md
+++ b/local/rest_api_gcbm/curl.md
@@ -35,10 +35,10 @@
             http://localhost:8080/gcbm/upload
 
     ```
-3. `/gcbm/dynamic`
+3. `/gcbm/run`
 
     ```
-        curl -d "title=run4" -X POST http://localhost:8080/gcbm/dynamic
+        curl -d "title=run4" -X POST http://localhost:8080/gcbm/run
     ```
 
 4. `/gcbm/status`

--- a/local/tests/test_rest_gcbm.py
+++ b/local/tests/test_rest_gcbm.py
@@ -275,19 +275,19 @@ class TestApiFlintGCBM:
         upload_response = requests.post(upload_endpoint, files=upload_files, data=data)
         assert upload_response.status_code == 200
 
-    def test_dynamic(self, gcbm_endpoint, yield_title):
-        """ This test would check whether the dynamic endpoint \
+    def test_run(self, gcbm_endpoint, yield_title):
+        """ This test would check whether the run endpoint \
             is working or not with the title provided by the \
             yield_title fixture. This test would start the GCBM \
-            Dynamic Implementation of FLINT under the title provided \
+            Implementation of FLINT under the title provided \
             by yield_title fixture and already uploaded files."""
         data = {
             "title": yield_title,
         }
-        dynamic_endpoint = gcbm_endpoint + "dynamic"
-        dynamic_response = requests.post(dynamic_endpoint, data=data)
-        assert dynamic_response.status_code == 200
-        assert dynamic_response.json().get("status") == "Run started"
+        run_endpoint = gcbm_endpoint + "run"
+        run_response = requests.post(run_endpoint, data=data)
+        assert run_response.status_code == 200
+        assert run_response.json().get("status") == "Run started"
 
     def test_status(self, gcbm_endpoint, yield_title):
         """ This test would check whether the status endpoint \


### PR DESCRIPTION
# Pull Request Template

Solves #149  

Renamed the `gcbm/dynamic` endpoint to `/gcbm/run`


