### PR TITLE
chore: move preprocessing from `/gcbm/upload` to `/gcbm/dynamic` endpoint

### DIFF
--- a/.github/workflows/cml-report.yml
+++ b/.github/workflows/cml-report.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   generate_cml_report:
-    if:  ${{ github.event.label.name == ['run-simulation'] }}
+    if:  github.event.label.name == 'run-simulation'
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/local/rest_api_gcbm/app.py
+++ b/local/rest_api_gcbm/app.py
@@ -225,10 +225,6 @@ def gcbm_upload():
     else:
         return {"error": "Missing configuration file"}, 400
 
-    get_config_templates(input_dir)
-    get_modules_cbm_config(input_dir)
-    get_provider_config(input_dir)
-
     return {
         "data": "All files uploaded succesfully. Proceed to the next step of the API at gcbm/dynamic."
     }
@@ -574,7 +570,6 @@ def get_provider_config(input_dir):
 
             # copy files to input directory
             for i in paths:
-                print(i)
                 shutil.copy2(i, (f"{input_dir}"))
 
         # delete folders from input directory
@@ -624,8 +619,9 @@ def gcbm_dynamic():
     title = "".join(c for c in title if c.isalnum())
     input_dir = f"{os.getcwd()}/input/{title}"
 
-    gcbm_config_path = "gcbm_config.cfg"
-    provider_config_path = "provider_config.json"
+    get_config_templates(input_dir)
+    get_modules_cbm_config(input_dir)
+    get_provider_config(input_dir)
 
     if not os.path.exists(f"{input_dir}"):
         os.makedirs(f"{input_dir}")


### PR DESCRIPTION
# Pull Request Template

## Description

In this PR : 
1. The functions `get_config_templates`, `get_modules_cbm_config` and `get_provider_config` are moved from the `/gcbm/upload` to `/gcbm/dynamic` endpoints. This will allow both the variants to work, upload all files to a single endpoint and upload files to separate endpoints, `/upload/db/`, `/upload/classifiers` etc
2. Remove the debug statement that prints the file path

cc : @SanjaySinghRajpoot 
