### PR TITLE
feat: endpoint to rename a table

### DIFF
--- a/local/rest_api_gcbm/app.py
+++ b/local/rest_api_gcbm/app.py
@@ -629,6 +629,36 @@ def send_table():
         resp[table_name[0]] = schema
     return resp, 200
 
+@app.route("/gcbm/table/rename", methods=['POST'])
+def rename_table():
+    """
+    Rename a table
+    ---
+    tags:
+            - gcbm
+    responses:
+            200:
+    parameters:
+            - in: Params
+            name: title
+                    type: string
+            name: previous
+                    type: string
+            nsme: new
+                    type: string
+            description: Status indicating success/failure in performing the rename
+    """
+    title = request.form.get("title") or "simulation"
+    input_dir = f"{os.getcwd()}/input/{title}/db/"
+    try:
+        connection = sqlite3.connect(input_dir + "gcbm_input.db")
+        cursor = connection.cursor()
+        previous_name = request.form.get('previous')
+        new_name = request.form.get('new')    
+        cursor.execute(f"ALTER TABLE {previous_name} rename to {new_name}")
+        return {"status": 1}
+    except Exception as exception:
+        return {"status": 0, "error": str(exception)}
 
 @app.route("/gcbm/dynamic", methods=["POST"])
 def gcbm_dynamic():


### PR DESCRIPTION
# Pull Request Template

## Description

This PR adds an endpoint to rename a table.

A post request is made as

```
 curl -d "title=run4&previous=old-table-name&new=new-table-name" -X POST http://localhost:8080/gcbm/table/rename
```

As an example, to change `turnover_parameter` to `new-turnover_parameter`

curl -d "title=run4&previous=turnover_parameter&new=new_turnover_parameter" -X POST http://localhost:8080/gcbm/table/rename

Fixes #174 

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

![image](https://user-images.githubusercontent.com/53875297/187404427-ba563b50-ae94-4c7d-becb-08db40785184.png)

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
