### PR TITLE
feat: Added a new GCBM status endpoint

### DIFF
--- a/local/tests/test_rest_gcbm.py
+++ b/local/tests/test_rest_gcbm.py
@@ -1,4 +1,5 @@
 from distutils.command.upload import upload
+import re
 from pkg_resources import yield_lines
 import pytest
 import requests
@@ -371,6 +372,11 @@ class TestApiFlintGCBM:
         upload_endpoint = gcbm_endpoint + "upload/db"
         upload_response = requests.post(upload_endpoint, files=upload_files, data=data)
         assert upload_response.status_code == 200
+    
+    def test_gcbm_status(self, gcbm_endpoint):
+        get_status_endpoint = gcbm_endpoint + "status"
+        get_status = requests.get(get_status_endpoint);
+        assert get_status.status_code == 200
 
     @pytest.mark.skip(reason="Test fails on CI")
     def test_download(self, gcbm_endpoint, yield_title):


### PR DESCRIPTION
# Pull Request Template

## Description

A new endpoint is created called `/gcbm/status`. This endpoint will return the status of the running GCBM simulation and the logs generated in `simulation.txt`. This endpoint will be called by the FLINT-UI to get the latest status of the GCBM simulation. In this manner, the user will be able to check if everything is working correctly or if there is any error. If the simulation is not running a `400` status will be returned to the user. 

Fixes #179

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?
![Screenshot_20220907_172437](https://user-images.githubusercontent.com/67458417/188876581-c0e0e57d-fcb4-47e3-98de-38db8bbe3bcf.png)

It has been tested on a local host. The above image giving a error message as no simulation is running. 
