### PR TITLE
chore:removed /rothc endpoint description from swagger documentation of rest api gcbm

### DIFF
--- a/local/rest_api_gcbm/static/swagger.json
+++ b/local/rest_api_gcbm/static/swagger.json
@@ -98,20 +98,6 @@
                 ]
             }
         },
-        "/rothc": {
-            "post": {
-                "description": "",
-                "responses": {
-                    "200": {
-                        "description": "RothC based example FLINT"
-                    }
-                },
-                "summary": "Get RothC example of FLINT",
-                "tags": [
-                    "rothc"
-                ]
-            }
-        },
         "/version": {
             "get": {
                 "description": "",


### PR DESCRIPTION
Currently, the swagger.json file of the gcbm file contains the /rothc endpoint description. There is no endpoint of /rothc currently present for the rest api gcbm. 

Fixes #131 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

I have tested this locally. This is the screenshot of the current swagger documentation.
<img width="1440" alt="Screen Shot 2022-10-13 at 11 16 06 AM" src="https://user-images.githubusercontent.com/47720307/195571407-3032b19c-6068-4ee6-a38e-b1dd987a5c79.png">

It can be tested by going to the `<baseurl>/swagger`


## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [ ] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.


