### PR TITLE
added a check to /download endpoint in gcbm 

### DIFF
--- a/local/rest_api_gcbm/README.md
+++ b/local/rest_api_gcbm/README.md
@@ -1,38 +1,89 @@
-# FLINT.Cloud
- 
-### GCBM local-run REST API Setup  
- 
-Run the GCBM local-run container by pushing the following command:
+# GCBM REST API Setup
 
-```bash
-docker-compose up
-```
+The simulation is currently supported on Linux/macOS. To run the GCBM simulation locally, execute the following steps:
 
-Navigate to http://localhost:8080/ in the browser. You can stop the running container by pushing the following command:
+1. Clone the `FLINT.Cloud` repository using the command:
 
-```bash
-docker-compose down
-```
+  ```bash
+  git clone https://github.com/moja-global/FLINT.Cloud.git
+  ```
 
-Currently the REST API has the following endpoints available for access:-
+2. Navigate to the `rest_api_gcbm` directory: 
+  ```bash
+  cd FLINT.Cloud/local/rest_api_gcbm
+  ```
+
+3. Build the docker image with the image name `gcbm-api`:
+  ```bash
+  docker build --build-arg BUILD_TYPE=RELEASE --build-arg NUM_CPU=4 -t gcbm-api .
+  ```
+
+4. Create a container using the `gcbm-api` image and start it:
+ ```bash
+ docker run --rm -p 8080:8080 gcbm-api
+ ```
+
+Navigate to http://localhost:8080/ in the browser to test the various endpoints available.
+
+## Endpoints
+
+The GCBM REST API has the following endpoints available for access:
  
 |      Endpoint     | Functionality | Method | 
 | :----------------: | :----------------: | :----------------: | 
-|   **\help\all**    | This endpoint produces a help message with information on all options for moja.CLI | `GET`
-|   **\help\arg**    |  This endpoint produces a help message with information on option arg for moja.CLI. | `GET`
-|   **\gcbm\new**    |  This endpoint creates a new directory to store input and output files of the simulation. Parameter to be passed in the body is the title of the new simulation or default value simulation will be used.   | `POST` |
-|  **\gcbm\upload**  | This endpoint is used to upload the input files: config_files, input and database. Remember to upload the files in the body from the GCBM folder which is available in the root of this repository for setup and use. A directory /input will be created to store the specified files. | `POST` |
-| **\gcbm\dynamic**  |  This endpoint runs simulation in a thread and generates an output zip file in /output directory. The process may take a while. Parameter is the title of the simulation. | `POST` |
-|  **\gcbm\status**  | This endpoint is employed to check the status of the simulation. It sends a message 'Output is ready to download' to notify that the output zip file is generated. Parameter is the title of the simulation. | `POST`
-|  **\gcbm\download**  | This endpoint is used to download the output zip file. Parameter is the title of the simulation. | `POST`
-|  **\gcbm\list**  | This endpoint retrieves the complete list of simulations that are created using /new.  | `GET`
+|   **/help/all**    | This endpoint produces a help message with information on all options for moja.CLI | `GET`
+|   **/help/arg**    |  This endpoint produces a help message with information on option arg for moja.CLI. | `GET`
+|   **/gcbm/new**    |  This endpoint creates a new directory to store input and output files of the simulation. Parameter to be passed in the body is the title of the new simulation or default value simulation will be used.   | `POST` |
+|  **/gcbm/upload**  | This endpoint is used to upload the input files: config_files, input and database. Remember to upload the files in the body from the GCBM folder which is available in the root of this repository for setup and use. A directory /input will be created to store the specified files. | `POST` |
+| **/gcbm/run**  |  This endpoint runs simulation in a thread and generates an output zip file in /output directory. The process may take a while. Parameter is the title of the simulation. | `POST` |
+|  **/gcbm/status**  | This endpoint is employed to check the status of the simulation. It sends a message 'Output is ready to download' to notify that the output zip file is generated. Parameter is the title of the simulation. | `POST`
+|  **/gcbm/download**  | This endpoint is used to download the output zip file. Parameter is the title of the simulation. | `POST`
+|  **/gcbm/list**  | This endpoint retrieves the complete list of simulations that are created using /new.  | `GET`
 
-The inputs are contained in `GCBM_Demo_Run.zip`, present in the root of the directory. This file must be unzipped for further usage.
+The inputs are contained in `GCBM_New_Demo_Run.zip`, present in the root of the directory. This file must be unzipped for further usage. Once the container is up and running, the following methods can be used to interact with the endpoints:
 
-<h3> Once the container is up and running, the following methods can be used to interact with the endpoints </h3>
+1. A sample collection is available [in our Postaman collection](https://github.com/nynaalekhya/FLINT.Cloud/blob/local-gcbm-run/rest_local_run/local_run.postman_collection). Import the collection to Postman and run the endpoints.
 
-1. A sample Postman collection is available [here](https://github.com/nynaalekhya/FLINT.Cloud/blob/local-gcbm-run/rest_local_run/local_run.postman_collection). Import the collection to Postman and run the endpoints.
+2. The endpoints can be interacted with using `cURL`. `cURL` is used in command lines or scripts to transfer data. Find out more about curl [on the official website](https://curl.se/). Commands using `cURL` can be found [in our documentation](curl.md)
 
-2. The endpoints can be interacted with using `cURL`. 
-curl is used in command lines or scripts to transfer data. Find out more about curl [here](https://curl.se/). Commands using cURL can be found [here](curl.md)
+## Running a GCBM simulation
 
+To run the endpoints and start a new GCBM simulation : 
+
+1. Unzip `GCBM_New_Demo_Run` and open a terminal inside the folder and run the following curl commands:
+ 
+2. Create a new simulation (the default title of the simulation is `simulation`; Here the title `run4` is used): 
+   ```bash
+   curl -d "title=run4" -X POST http://localhost:8080/gcbm/new
+   ````
+
+3. Upload the input files:
+   ```bash
+   curl -F disturbances='@disturbances/disturbances_2011_moja.tiff' \
+        -F disturbances='@disturbances/disturbances_2012_moja.tiff' \
+        -F disturbances='@disturbances/disturbances_2013_moja.tiff' \
+        -F disturbances='@disturbances/disturbances_2014_moja.tiff' \
+        -F disturbances='@disturbances/disturbances_2015_moja.tiff' \
+        -F disturbances='@disturbances/disturbances_2016_moja.tiff' \
+        -F disturbances='@disturbances/disturbances_2018_moja.tiff' \
+        -F classifiers='@classifiers/Classifier1_moja.tiff' \
+        -F classifiers='@classifiers/Classifier2_moja.tiff' \
+        -F db='@db/gcbm_input.db' \
+        -F miscellaneous='@miscellaneous/initial_age_moja.tiff' \
+        -F miscellaneous='@miscellaneous/mean_annual_temperature_moja.tiff' \
+        -F title="run4" \
+        http://localhost:8080/gcbm/upload
+    ```
+
+4. To start the simulation, run:
+   ```bash
+   curl -d "title=run4" -X POST http://localhost:8080/gcbm/run
+   ```
+   
+   It should take around 35-40 minutes to finish running and even less depending on your local machine specifications. The end message should be `SQLite insert complete`. The message would be printed on the terminal used to execute Docker commands.
+    
+   
+5. To download the simulation outputs, run the following curl command 3-5 minutes after the simulation has finished running:
+   ```bash
+   curl -d "title=run4" -X POST http://localhost:8080/gcbm/download -L -o run4.zip
+   ```

--- a/local/rest_api_gcbm/app.py
+++ b/local/rest_api_gcbm/app.py
@@ -462,9 +462,24 @@ def gcbm_download():
     title = request.form.get("title") or "simulation"
     # Sanitize title
     title = "".join(c for c in title if c.isalnum())
+
+    output_dir = f"{os.getcwd()}/output/{title}.zip"
+    input_dir = f"{os.getcwd()}/input/{title}"
+
+    # if the title has an input simulation and there is no output simulation then they should check the status.
+    if not os.path.exists(f"{output_dir}") and os.path.exists(f"{input_dir}"):
+        return {
+            "message": "You simulation is currently running, check the status via /gcbm/status"
+        }
+
+    # if there is no input simulation and no output simulation then the simulation does not exist.
+    elif not os.path.exists(f"{output_dir}") and not os.path.exists(f"{input_dir}"):
+        return {
+            "message": "You don't have a simulation with this title kindly check the title and try again"
+        }
+
     return send_file(
-        f"{os.getcwd()}/output/{title}.zip",
-        attachment_filename="{title}.zip",
+        f"{os.getcwd()}/output/{title}.zip", attachment_filename="{title}.zip",
     )
 
 
@@ -484,10 +499,13 @@ def gcbm_list_simulations():
     for file in os.listdir(f"{os.getcwd()}/input"):
         list.append(file)
 
-    return {
-        "data": list,
-        "message": "To create a new simulation, create a request at gcbm/new. To access the results of the existing simulations, create a request at gcbm/download.",
-    }, 200
+    return (
+        {
+            "data": list,
+            "message": "To create a new simulation, create a request at gcbm/new. To access the results of the existing simulations, create a request at gcbm/download.",
+        },
+        200,
+    )
 
 
 @app.route("/gcbm/status", methods=["POST"])

--- a/local/rest_api_gcbm/curl.md
+++ b/local/rest_api_gcbm/curl.md
@@ -1,29 +1,32 @@
 <h3> GCBM API Endpoints </h3>
 
 ### Create a new GCBM simulation
+
 The title of a new simulation can be passed or the default title `simulation` will be used. (i.e the default title of the simulation is `simulation`, here the title `run4` is used)
 
-| **Method** | **Endpoint** | **Response code** | 
-|---  | ---| --- |
-| POST| `/gcbm/new` | 200 OK (Success) |
-
+| **Method** | **Endpoint** | **Response code** |
+| ---------- | ------------ | ----------------- |
+| POST       | `/gcbm/new`  | 200 OK (Success)  |
 
 Example:
+
 ```
 curl -d "title=run4" -X POST http://localhost:8080/gcbm/new
 ```
 
 Expected response (Success):
+
 ```json
 {
-  "data":  "New simulation started. Please move on to the next stage for uploading files at /gcbm/upload." 
+  "data": "New simulation started. Please move on to the next stage for uploading files at /gcbm/upload."
 }
 ```
 
-### Upload configuration files 
+### Upload configuration files
+
 Upload all of the files required to run the simulation.
-| **Method** | **Endpoint** | **Response codes** | 
-|---  | ---| --- |
+| **Method** | **Endpoint** | **Response codes** |
+|--- | ---| --- |
 | POST| `/gcbm/upload` | 200 OK (Success), 400 (Error) |
 
 Example:
@@ -54,19 +57,154 @@ curl -F disturbances='@disturbances/disturbances_2011_moja.tiff' \
 ```
 
 Expected response (Success):
+
 ```json
 {
   "data": "All files uploaded succesfully. Proceed to the next step of the API at gcbm/dynamic."
 }
 ```
 
-### Run the simulation 
+You can upload all the simulation files at once or upload them separately. To upload files separately follow the commands below.
+
+### Upload Disturbances file
+
+Upload Disturbances file to run the simulation.
+| **Method** | **Endpoint** | **Response codes** |
+|--- | ---| --- |
+| POST| `/gcbm/upload/disturbances` | 200 OK (Success), 400 (Error) |
+
+Example:
+
+Go to the location of the unzipped file `GCBM_New_Demo_Run.zip`
+
+```
+cd path-to-unzipped-file
+```
+
+Upload all the files present in the disturbances folder.
+
+```
+curl -F disturbances='@disturbances/disturbances_2011_moja.tiff' \
+		-F disturbances='@disturbances/disturbances_2012_moja.tiff' \
+		-F disturbances='@disturbances/disturbances_2013_moja.tiff' \
+		-F disturbances='@disturbances/disturbances_2014_moja.tiff' \
+		-F disturbances='@disturbances/disturbances_2015_moja.tiff' \
+		-F disturbances='@disturbances/disturbances_2016_moja.tiff' \
+		-F disturbances='@disturbances/disturbances_2018_moja.tiff' \
+		-F title="run4" \
+		http://localhost:8080/gcbm/upload/disturbances
+```
+
+Expected response (Success):
+
+```json
+{
+  "data": "Disturbances file uploaded succesfully. Proceed to the next step."
+}
+```
+
+### Upload Classifiers file
+
+Upload Classifiers file to run the simulation.
+| **Method** | **Endpoint** | **Response codes** |
+|--- | ---| --- |
+| POST| `/gcbm/upload/classifiers` | 200 OK (Success), 400 (Error) |
+
+Example:
+
+Go to the location of the unzipped file `GCBM_New_Demo_Run.zip`
+
+```
+cd path-to-unzipped-file
+```
+
+Upload all the files present in the disturbances folder.
+
+```
+curl -F classifiers='@classifiers/Classifier1_moja.tiff' \
+		-F classifiers='@classifiers/Classifier2_moja.tiff' \
+		-F title="run4" \
+		http://localhost:8080/gcbm/upload/classifiers
+```
+
+Expected response (Success):
+
+```json
+{
+  "data": "Classifiers file uploaded succesfully. Proceed to the next step."
+}
+```
+
+### Upload Miscellaneous file
+
+Upload Miscellaneous file to run the simulation.
+| **Method** | **Endpoint** | **Response codes** |
+|--- | ---| --- |
+| POST| `/gcbm/upload/miscellaneous` | 200 OK (Success), 400 (Error) |
+
+Example:
+
+Go to the location of the unzipped file `GCBM_New_Demo_Run.zip`
+
+```
+cd path-to-unzipped-file
+```
+
+Upload all the files present in the disturbances folder.
+
+```
+curl -F miscellaneous='@miscellaneous/initial_age_moja.tiff' \
+		-F miscellaneous='@miscellaneous/mean_annual_temperature_moja.tiff' \
+		-F title="run4" \
+		http://localhost:8080/gcbm/upload/miscellaneous
+```
+
+Expected response (Success):
+
+```json
+{
+  "data": "Miscellaneous file uploaded succesfully. Proceed to the next step."
+}
+```
+
+### Upload db file
+
+Upload db file to run the simulation.
+| **Method** | **Endpoint** | **Response codes** |
+|--- | ---| --- |
+| POST| `/gcbm/upload/db` | 200 OK (Success), 400 (Error) |
+
+Example:
+
+Go to the location of the unzipped file `GCBM_New_Demo_Run.zip`
+
+```
+cd path-to-unzipped-file
+```
+
+Upload all the files present in the disturbances folder.
+
+```
+curl -F db='@db/gcbm_input.db' \
+		-F title="run4" \
+		http://localhost:8080/gcbm/upload/db
+```
+
+Expected response (Success):
+
+```json
+{
+  "data": "db file uploaded succesfully. Proceed to the next step."
+}
+```
+
+### Run the simulation
+
 After uploading your files, you can run the simulation through this endpoint.
 
-| **Method** | **Endpoint** | **Response code** | 
-|---  | ---| --- |
-| POST | `/gcbm/dynamic` | 200 OK (Success) |
-
+| **Method** | **Endpoint**    | **Response code** |
+| ---------- | --------------- | ----------------- |
+| POST       | `/gcbm/dynamic` | 200 OK (Success)  |
 
 Example:
 
@@ -75,25 +213,25 @@ curl -d "title=run4" -X POST http://localhost:8080/gcbm/dynamic
 ```
 
 Expected response (Success):
+
 ```json
 {
   "status": "Run started"
 }
 ```
 
-### Get status of the simulation 
+### Get status of the simulation
 
-| **Method** | **Endpoint** | **Response code** | 
-|---  | ---| --- |
-| POST | `/gcbm/status` | 200 OK (Success) |
-
+| **Method** | **Endpoint**   | **Response code** |
+| ---------- | -------------- | ----------------- |
+| POST       | `/gcbm/status` | 200 OK (Success)  |
 
 ```
 curl -d "title=run4" -X POST http://localhost:8080/gcbm/status
 ```
 
-
 Expected response (In progress):
+
 ```json
 {
   "finished": "In Progress"
@@ -101,16 +239,18 @@ Expected response (In progress):
 ```
 
 Expected response (When simulation completes):
+
 ```json
 {
   "finished": "Output is ready to download at gcbm/download"
 }
 ```
 
-### Download the result of simulation 
-| **Method** | **Endpoint** | **Response code** | 
-|---  | ---| --- |
-| POST | `/gcbm/download` | 200 OK (Success) |
+### Download the result of simulation
+
+| **Method** | **Endpoint**     | **Response code** |
+| ---------- | ---------------- | ----------------- |
+| POST       | `/gcbm/download` | 200 OK (Success)  |
 
 A file named `output.zip` will be obtained. This file contains the outputs generated, which can be analysed on unzipping.
 
@@ -118,16 +258,18 @@ A file named `output.zip` will be obtained. This file contains the outputs gener
 curl -d "title=run4" -X POST http://localhost:8080/gcbm/download -L -o run4.zip
 ```
 
-### List all of the simulations 
-| **Method** | **Endpoint** | **Response code** | 
-|---  | ---| --- |
-| GET | `/gcbm/list` | 200 OK (Success) |
+### List all of the simulations
+
+| **Method** | **Endpoint** | **Response code** |
+| ---------- | ------------ | ----------------- |
+| GET        | `/gcbm/list` | 200 OK (Success)  |
 
 ```
 curl http://localhost:8080/gcbm/list
 ```
 
 Expected response (Success):
+
 ```json
 {
   "data": ["run4"],

--- a/local/rest_api_gcbm/static/swagger.json
+++ b/local/rest_api_gcbm/static/swagger.json
@@ -98,20 +98,6 @@
                 ]
             }
         },
-        "/rothc": {
-            "post": {
-                "description": "",
-                "responses": {
-                    "200": {
-                        "description": "RothC based example FLINT"
-                    }
-                },
-                "summary": "Get RothC example of FLINT",
-                "tags": [
-                    "rothc"
-                ]
-            }
-        },
         "/version": {
             "get": {
                 "description": "",


### PR DESCRIPTION

## Description

Currently, when you try to download a gcbm output, there is no check if the title exists or not. It goes ahead and shows an internal server error. 

Fixes #126 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
If you try to download the output of the non-existed simulation, you get the response below.

<img width="1000" alt="Screen Shot 2022-10-16 at 1 48 50 PM" src="https://user-images.githubusercontent.com/47720307/196036281-16a4bbd1-30e1-4a64-b263-513925caf14f.png">

Also, for simulations still in progress, or an error encountered somewhere, it refers them to check the status of the run.


...
<img width="1014" alt="Screen Shot 2022-10-16 at 1 50 33 PM 3" src="https://user-images.githubusercontent.com/47720307/196036433-ea437594-2196-4245-9a26-d34727f32ac3.png">



## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [ ] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
