### PR TITLE
fix:added a check to see if simulation output exists

### DIFF
--- a/local/rest_api_gcbm/app.py
+++ b/local/rest_api_gcbm/app.py
@@ -462,9 +462,24 @@ def gcbm_download():
     title = request.form.get("title") or "simulation"
     # Sanitize title
     title = "".join(c for c in title if c.isalnum())
+
+    output_dir = f"{os.getcwd()}/output/{title}.zip"
+    input_dir = f"{os.getcwd()}/input/{title}"
+
+    # if the title has an input simulation and there is no output simulation then they should check the status.
+    if not os.path.exists(f"{output_dir}") and os.path.exists(f"{input_dir}"):
+        return {
+            "message": "You simulation is currently running, check the status via /gcbm/status"
+        }
+
+    # if there is no input simulation and no output simulation then the simulation does not exist.
+    elif not os.path.exists(f"{output_dir}") and not os.path.exists(f"{input_dir}"):
+        return {
+            "message": "You don't have a simulation with this title kindly check the title and try again"
+        }
+
     return send_file(
-        f"{os.getcwd()}/output/{title}.zip",
-        attachment_filename="{title}.zip",
+        f"{os.getcwd()}/output/{title}.zip", attachment_filename="{title}.zip",
     )
 
 
@@ -484,10 +499,13 @@ def gcbm_list_simulations():
     for file in os.listdir(f"{os.getcwd()}/input"):
         list.append(file)
 
-    return {
-        "data": list,
-        "message": "To create a new simulation, create a request at gcbm/new. To access the results of the existing simulations, create a request at gcbm/download.",
-    }, 200
+    return (
+        {
+            "data": list,
+            "message": "To create a new simulation, create a request at gcbm/new. To access the results of the existing simulations, create a request at gcbm/download.",
+        },
+        200,
+    )
 
 
 @app.route("/gcbm/status", methods=["POST"])


### PR DESCRIPTION
## Description

Currently, when you try to download a gcbm output, there is no check if the title exists or not. It goes ahead and shows an internal server error. 

Fixes #126 

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?
If you try to download the output of the non-existed simulation, you get the response below.

<img width="1000" alt="Screen Shot 2022-10-16 at 1 48 50 PM" src="https://user-images.githubusercontent.com/47720307/196036281-16a4bbd1-30e1-4a64-b263-513925caf14f.png">

Also, for simulations still in progress, or an error encountered somewhere, it refers them to check the status of the run.


...
<img width="1014" alt="Screen Shot 2022-10-16 at 1 50 33 PM 3" src="https://user-images.githubusercontent.com/47720307/196036433-ea437594-2196-4245-9a26-d34727f32ac3.png">



## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [ ] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
