### PR TITLE
fix: Added a helpful error message

### DIFF
--- a/local/rest_api_gcbm/app.py
+++ b/local/rest_api_gcbm/app.py
@@ -336,10 +336,13 @@ def gcbm_dynamic():
     # Sanitize title
     title = "".join(c for c in title if c.isalnum())
     input_dir = f"{os.getcwd()}/input/{title}"
-
-    get_config_templates(input_dir)
-    get_modules_cbm_config(input_dir)
-    get_provider_config(input_dir)
+    
+    try:
+        get_config_templates(input_dir)
+        get_modules_cbm_config(input_dir)
+        get_provider_config(input_dir)
+    except:
+        return {"error": "please upload files before running dynamic endpoint"}, 400
 
     if not os.path.exists(f"{input_dir}"):
         os.makedirs(f"{input_dir}")


### PR DESCRIPTION
# Pull Request Template

## Description

Currently running the dynamic endpoint without uploading files prior returns a 500 internal server error, This error message is not helpful to the user. 

I used an exception to catch errors and return a more helpful message which tells the user to upload files before running the dynamic endpoint.

Fixes # https://github.com/moja-global/FLINT.Cloud/issues/207

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?
When you run the dynamic endpoint without uploading the files prior, the endpoint will return an error message telling you to do so.

![image](https://user-images.githubusercontent.com/94747637/198867522-02b0cbe0-5d24-4845-b847-f5fb45d4b3f5.png)

...

## Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
- [ ] I have tagged the reviewers in a comment below incase my pull request is ready for a review
- [ ] I have signed the commit message to agree to Developer Certificate of Origin (DCO) (to certify that you wrote or otherwise have the right to submit your contribution to the project.) by adding "--signoff" to my git commit command.

<!--- Thanks for opening this pull request! If the tests fail, please feel free to reach out to us by leaving a comment down below and we will be happy to take a look --->
