### PR TITLE
Updating API with Flask-RESTful

### DIFF
--- a/local/rest_api_gcbm/app.py
+++ b/local/rest_api_gcbm/app.py
@@ -521,16 +521,18 @@ def status():
     return {"finished": message}
 
 
-@app.route("/check", methods=["GET", "POST"])
-def check():
-    return "Checks OK", 200
+class check(Resource):
+    def get(self):
+        return {"Checks OK"}, 200
+    def post(self):
+        return {"Checks OK"}, 200
 
 class home(Resource):
     def get(self):
         return {"FLINT.Cloud API"}, 200
 
+api.add_resource(check, "/check")
 api.add_resource(home, '/')
-
 
 @app.route("/upload/title", methods=["POST"])
 def getTitle():


### PR DESCRIPTION
## Description

I have used Flask-RESTful to update the current API format. This is a small step in making FLINT. Cloud modular. This will help was follow the OOPs architecture that we are trying to implement. With the help of Flask-RESTful, we can separate the endpoint and its controllers. 


Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Tested the API endpoints on local host using Postman. 


